### PR TITLE
Support on_schema_change feature on incremental model

### DIFF
--- a/dbt/adapters/athena/__init__.py
+++ b/dbt/adapters/athena/__init__.py
@@ -1,3 +1,4 @@
+from dbt.adapters.athena.column import AthenaColumn
 from dbt.adapters.athena.connections import AthenaConnectionManager
 from dbt.adapters.athena.connections import AthenaCredentials
 from dbt.adapters.athena.impl import AthenaAdapter

--- a/dbt/adapters/athena/column.py
+++ b/dbt/adapters/athena/column.py
@@ -1,0 +1,20 @@
+from dbt.adapters.base import Column as BaseColumn
+
+
+class AthenaColumn(BaseColumn):
+    @property
+    def data_type(self) -> str:
+        # NOTE: Athena has different types between DML and DDL, use DDL type in this case
+        #       ref: https://docs.aws.amazon.com/athena/latest/ug/data-types.html
+        if self.dtype.lower() == "integer":
+            return "int"
+        elif self.is_string():
+            return self.string_type(self.string_size())
+        elif self.is_numeric():
+            return self.numeric_type(self.dtype, self.numeric_precision, self.numeric_scale)
+        else:
+            return self.dtype
+
+    @classmethod
+    def string_type(cls, size: int) -> str:
+        return "varchar({})".format(size)

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -11,6 +11,7 @@ from dbt.adapters.base.impl import GET_CATALOG_MACRO_NAME
 from dbt.adapters.base.relation import BaseRelation, InformationSchema
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.athena import AthenaConnectionManager
+from dbt.adapters.athena.column import AthenaColumn
 from dbt.adapters.athena.relation import AthenaRelation, AthenaSchemaSearchMap
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import Manifest
@@ -23,6 +24,7 @@ boto3_client_lock = Lock()
 class AthenaAdapter(SQLAdapter):
     ConnectionManager = AthenaConnectionManager
     Relation = AthenaRelation
+    Column = AthenaColumn
 
     @classmethod
     def date_function(cls) -> str:

--- a/dbt/include/athena/macros/adapters/columns.sql
+++ b/dbt/include/athena/macros/adapters/columns.sql
@@ -20,3 +20,41 @@
   {% set table = load_result('get_columns_in_relation').table %}
   {% do return(sql_convert_columns_in_relation(table)) %}
 {% endmacro %}
+
+{% macro alter_relation_add_columns(relation, add_columns = none) -%}
+  {% if add_columns is none %}
+    {% set add_columns = [] %}
+  {% endif %}
+
+  {% set sql -%}
+      alter {{ relation.type }} {{ relation }}
+          add columns (
+            {%- for column in add_columns -%}
+                {{ column.name }} {{ column.data_type }}{{ ', ' if not loop.last }}
+            {%- endfor -%}
+          )
+  {%- endset -%}
+
+  {% if (add_columns | length) > 0 %}
+    {{ return(run_query(sql)) }}
+  {% endif %}
+{% endmacro %}
+
+{% macro alter_relation_replace_columns(relation, replace_columns = none) -%}
+  {% if replace_columns is none %}
+    {% set replace_columns = [] %}
+  {% endif %}
+
+  {% set sql -%}
+      alter {{ relation.type }} {{ relation }}
+          replace columns (
+            {%- for column in replace_columns -%}
+                {{ column.name }} {{ column.data_type }}{{ ', ' if not loop.last }}
+            {%- endfor -%}
+          )
+  {%- endset -%}
+
+  {% if (replace_columns | length) > 0 %}
+    {{ return(run_query(sql)) }}
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/athena/macros/materializations/models/incremental/on_schema_change.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/on_schema_change.sql
@@ -1,0 +1,27 @@
+{% macro sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}
+  {%- set partitioned_by = config.get('partitioned_by', default=none) -%}
+  {%- if partitioned_by is none -%}
+      {%- set partitioned_by = [] -%}
+  {%- endif %}
+  {%- set add_to_target_arr = schema_changes_dict['source_not_in_target'] -%}
+  {%- set replace_with_target_arr = remove_partitions_from_columns(schema_changes_dict['source_columns'], partitioned_by) -%}
+  {%- if on_schema_change == 'append_new_columns'-%}
+     {%- if add_to_target_arr | length > 0 -%}
+       {%- do alter_relation_add_columns(target_relation, add_to_target_arr) -%}
+     {%- endif -%}
+  {% elif on_schema_change == 'sync_all_columns' %}
+     {%- set remove_from_target_arr = schema_changes_dict['target_not_in_source'] -%}
+     {%- set new_target_types = schema_changes_dict['new_target_types'] -%}
+     {% if add_to_target_arr | length > 0 or remove_from_target_arr | length > 0 or new_target_types | length > 0 %}
+       {%- do alter_relation_replace_columns(target_relation, replace_with_target_arr) -%}
+     {% endif %}
+  {% endif %}
+  {% set schema_change_message %}
+    In {{ target_relation }}:
+        Schema change approach: {{ on_schema_change }}
+        Columns added: {{ add_to_target_arr }}
+        Columns removed: {{ remove_from_target_arr }}
+        Data types changed: {{ new_target_types }}
+  {% endset %}
+  {% do log(schema_change_message) %}
+{% endmacro %}


### PR DESCRIPTION
This PR was originally created by @hiro-o918 over at: https://github.com/Tomme/dbt-athena/pull/114

**Problem**

Currently, dbt-athena does not support on_schema_change option.
closes https://github.com/Tomme/dbt-athena/issues/47

**Solution**

- Add custom column class AthenaColumn


Athena has different column type between DML and DDL (e.g. integer)

- https://docs.aws.amazon.com/athena/latest/ug/data-types.html

To avoid error on alter table statement because of difference of column type

- Overwrite macro sync_column_schemas

Athena does not support drop columns statement, but replace columns

- https://docs.aws.amazon.com/athena/latest/ug/alter-table-replace-columns.html

this causes inconsistency with original sync_column_schemas, so overwrite this macro on this adaptor