### PR TITLE
Get model owner from manifest

### DIFF
--- a/dbt/include/athena/macros/adapters/metadata.sql
+++ b/dbt/include/athena/macros/adapters/metadata.sql
@@ -17,7 +17,6 @@
                             else table_type
                         end as table_type,
 
-                        null as table_owner,
                         null as table_comment
 
                     from {{ information_schema }}.tables
@@ -54,8 +53,7 @@
                         columns.column_name,
                         columns.column_index,
                         columns.column_type,
-                        columns.column_comment,
-                        tables.table_owner
+                        columns.column_comment
 
                     from tables
                     join columns


### PR DESCRIPTION
_We've been running an internal fork of dbt-athena for little while, so I'm bringing over a few PRs we've made to this new awesome community release 😄_ 

---

This PR fixes the issue where setting the owner in schema.yml did not propagate to generated dbt docs.

The issue was cause by having null as table_owner, in metadata.sql file.

Because the table owner is not populated in Athena catalog, the simplest fix was to parse the manifest after the catalog is retrieved and manually append the owner to each model. Because the athena__get_catalog macro in metadata.sql always returned null for table_owner I completely removed that column and it gets appended when adding the owner from manifest instead.

**Results**

When you define:

```yml
models:
  - name: batch_decision_checks
    config:
      tags:
        - a_foo_tag
        - another_foo_tag
      meta:
        owner: "first_foo_owner"
```

The output is:
![Screenshot 2022-10-26 at 14 09 29](https://user-images.githubusercontent.com/38856126/198034646-b3df2665-392a-4532-9872-09fcc7f21170.png)

When you don't set an owner, such as:

```yml
models:
  - name: bbb_loanbook
    config:
      tags:
        - a_foo_tag
        - another_foo_tag
```

The output is:
![Screenshot 2022-10-26 at 14 09 35](https://user-images.githubusercontent.com/38856126/198034834-25f605d2-cccf-4084-a1da-a982ffe38665.png)