### PR TITLE
Support on_schema_change feature on incremental model

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,7 +3,7 @@ name: Upload Python Package
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## v1.0.3
+* Fix issue on fetching partitions from glue, using pagination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,10 @@
+## v1.0.4
+
+### Bugfixes
+* Add support for partition fields of type timestamp
+
+### Features
+* ...
+
 ## v1.0.3
 * Fix issue on fetching partitions from glue, using pagination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### Bugfixes
 * Add support for partition fields of type timestamp
+* Use correct escaper for INSERT queries
+* Share same boto session between every calls
 
 ### Features
-* ...
+* Get model owner from manifest
 
 ## v1.0.3
 * Fix issue on fetching partitions from glue, using pagination

--- a/dbt/adapters/athena/__init__.py
+++ b/dbt/adapters/athena/__init__.py
@@ -1,3 +1,4 @@
+from dbt.adapters.athena.column import AthenaColumn
 from dbt.adapters.athena.connections import AthenaConnectionManager
 from dbt.adapters.athena.connections import AthenaCredentials
 from dbt.adapters.athena.impl import AthenaAdapter

--- a/dbt/adapters/athena/column.py
+++ b/dbt/adapters/athena/column.py
@@ -1,0 +1,20 @@
+from dbt.adapters.base import Column as BaseColumn
+
+
+class AthenaColumn(BaseColumn):
+    @property
+    def data_type(self) -> str:
+        # NOTE: Athena has different types between DML and DDL, use DDL type in this case
+        #       ref: https://docs.aws.amazon.com/athena/latest/ug/data-types.html
+        if self.dtype.lower() == "integer":
+            return "int"
+        elif self.is_string():
+            return self.string_type(self.string_size())
+        elif self.is_numeric():
+            return self.numeric_type(self.dtype, self.numeric_precision, self.numeric_scale)
+        else:
+            return self.dtype
+
+    @classmethod
+    def string_type(cls, size: int) -> str:
+        return "varchar({})".format(size)

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -214,9 +214,7 @@ class AthenaParameterFormatter(Formatter):
             raise ProgrammingError("Query is none or empty.")
         operation = operation.strip()
 
-        if operation.upper().startswith("SELECT") or operation.upper().startswith(
-            "WITH"
-        ):
+        if operation.upper().startswith(("SELECT", "WITH", "INSERT")):
             escaper = _escape_presto
         else:
             # Fixes ParseException that comes with newer version of PyAthena

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -51,7 +51,8 @@ class AthenaCredentials(Credentials):
         return self.host
 
     def _connection_keys(self) -> Tuple[str, ...]:
-        return "s3_staging_dir", "work_group", "region_name", "database", "schema", "poll_interval", "aws_profile_name", "endpoing_url"
+        return "s3_staging_dir", "work_group", "region_name", "database", "schema", "poll_interval", \
+               "aws_profile_name", "endpoing_url"
 
 
 class AthenaCursor(Cursor):

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -27,6 +27,8 @@ from tenacity.retry import retry_if_exception
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_exponential
 
+from dbt.adapters.athena.session import get_boto3_session
+
 logger = AdapterLogger("Athena")
 
 
@@ -141,13 +143,12 @@ class AthenaConnectionManager(SQLConnectionManager):
             handle = AthenaConnection(
                 s3_staging_dir=creds.s3_staging_dir,
                 endpoint_url=creds.endpoint_url,
-                region_name=creds.region_name,
                 schema_name=creds.schema,
                 work_group=creds.work_group,
                 cursor_class=AthenaCursor,
                 formatter=AthenaParameterFormatter(),
                 poll_interval=creds.poll_interval,
-                profile_name=creds.aws_profile_name,
+                session=get_boto3_session(connection),
                 retry_config=RetryConfig(
                     attempt=creds.num_retries,
                     exceptions=(

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -20,6 +20,7 @@ logger = AdapterLogger("Athena")
 
 boto3_client_lock = Lock()
 
+
 class AthenaAdapter(SQLAdapter):
     ConnectionManager = AthenaConnectionManager
     Relation = AthenaRelation
@@ -74,7 +75,8 @@ class AthenaAdapter(SQLAdapter):
         partitions = partition_pg.build_full_result().get('Partitions')
         s3_rg = re.compile('s3://([^/]*)/(.*)')
         for partition in partitions:
-            logger.debug("Deleting objects for partition '{}' at '{}'", partition["Values"], partition["StorageDescriptor"]["Location"])
+            logger.debug("Deleting objects for partition '{}' at '{}'", partition["Values"],
+                         partition["StorageDescriptor"]["Location"])
             m = s3_rg.match(partition["StorageDescriptor"]["Location"])
             if m is not None:
                 bucket_name = m.group(1)
@@ -159,7 +161,6 @@ class AthenaAdapter(SQLAdapter):
         filtered_table = self._catalog_filter_table(table, manifest)
         return self._join_catalog_table_owners(filtered_table, manifest)
 
-
     def _get_catalog_schemas(self, manifest: Manifest) -> AthenaSchemaSearchMap:
         info_schema_name_map = AthenaSchemaSearchMap()
         nodes: Iterator[CompileResultNode] = chain(
@@ -178,7 +179,7 @@ class AthenaAdapter(SQLAdapter):
         client = conn.handle
         with boto3_client_lock:
             athena_client = boto3.client('athena', region_name=client.region_name)
-        
+
         response = athena_client.get_data_catalog(Name=catalog_name)
         return response['DataCatalog']
 
@@ -205,7 +206,7 @@ class AthenaAdapter(SQLAdapter):
         }
         # If the catalog is `awsdatacatalog` we don't need to pass CatalogId as boto3 infers it from the account Id.
         if catalog_id:
-            kwargs['CatalogId'] = catalog_id        
+            kwargs['CatalogId'] = catalog_id
         page_iterator = paginator.paginate(**kwargs)
 
         relations = []

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -118,13 +118,35 @@ class AthenaAdapter(SQLAdapter):
     ) -> str:
         return super().quote_seed_column(column, False)
 
+
+    def _join_catalog_table_owners(self, table: agate.Table, manifest: Manifest) -> agate.Table:
+        owners = []
+        # Get the owner for each model from the manifest
+        for node in manifest.nodes.values():
+            if node.resource_type == "model":
+                owners.append({
+                    "table_database": node.database,
+                    "table_schema": node.schema,
+                    "table_name": node.alias,
+                    "table_owner": node.config.meta.get("owner"),
+                })
+        owners_table = agate.Table.from_object(owners)
+
+        # Join owners with the results from catalog
+        join_keys = ["table_database", "table_schema", "table_name"]
+        return table.join(
+            right_table=owners_table,
+            left_key=join_keys,
+            right_key=join_keys,
+        )
+
+
     def _get_one_catalog(
         self,
         information_schema: InformationSchema,
         schemas: Dict[str, Optional[Set[str]]],
         manifest: Manifest,
     ) -> agate.Table:
-
         kwargs = {"information_schema": information_schema, "schemas": schemas}
         table = self.execute_macro(
             GET_CATALOG_MACRO_NAME,
@@ -134,8 +156,8 @@ class AthenaAdapter(SQLAdapter):
             manifest=manifest,
         )
 
-        results = self._catalog_filter_table(table, manifest)
-        return results
+        filtered_table = self._catalog_filter_table(table, manifest)
+        return self._join_catalog_table_owners(filtered_table, manifest)
 
 
     def _get_catalog_schemas(self, manifest: Manifest) -> AthenaSchemaSearchMap:

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -63,16 +63,19 @@ class AthenaAdapter(SQLAdapter):
         with boto3_client_lock:
             glue_client = boto3.client('glue', region_name=client.region_name)
         s3_resource = boto3.resource('s3', region_name=client.region_name)
-        partitions = glue_client.get_partitions(
-            # CatalogId='123456789012', # Need to make this configurable if it is different from default AWS Account ID
-            DatabaseName=database_name,
-            TableName=table_name,
-            Expression=where_condition
-        )
-        p = re.compile('s3://([^/]*)/(.*)')
-        for partition in partitions["Partitions"]:
+        paginator = glue_client.get_paginator("get_partitions")
+        partition_params = {
+            "DatabaseName": database_name,
+            "TableName": table_name,
+            "Expression": where_condition,
+            "ExcludeColumnSchema": True,
+        }
+        partition_pg = paginator.paginate(**partition_params)
+        partitions = partition_pg.build_full_result().get('Partitions')
+        s3_rg = re.compile('s3://([^/]*)/(.*)')
+        for partition in partitions:
             logger.debug("Deleting objects for partition '{}' at '{}'", partition["Values"], partition["StorageDescriptor"]["Location"])
-            m = p.match(partition["StorageDescriptor"]["Location"])
+            m = s3_rg.match(partition["StorageDescriptor"]["Location"])
             if m is not None:
                 bucket_name = m.group(1)
                 prefix = m.group(2)

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -11,6 +11,7 @@ from dbt.adapters.base.impl import GET_CATALOG_MACRO_NAME
 from dbt.adapters.base.relation import BaseRelation, InformationSchema
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.athena import AthenaConnectionManager
+from dbt.adapters.athena.column import AthenaColumn
 from dbt.adapters.athena.relation import AthenaRelation, AthenaSchemaSearchMap
 from dbt.contracts.graph.compiled import CompileResultNode
 from dbt.contracts.graph.manifest import Manifest
@@ -23,6 +24,7 @@ boto3_client_lock = Lock()
 class AthenaAdapter(SQLAdapter):
     ConnectionManager = AthenaConnectionManager
     Relation = AthenaRelation
+    Column = AthenaColumn
 
     @classmethod
     def date_function(cls) -> str:

--- a/dbt/adapters/athena/query_headers.py
+++ b/dbt/adapters/athena/query_headers.py
@@ -1,9 +1,10 @@
 import dbt.adapters.base.query_headers
 
+
 class _QueryComment(dbt.adapters.base.query_headers._QueryComment):
     """
-    Athena DDL does not always respect /* ... */ block quotations. 
-    This function is the same as _QueryComment.add except that 
+    Athena DDL does not always respect /* ... */ block quotations.
+    This function is the same as _QueryComment.add except that
     a leading "-- " is prepended to the query_comment and any newlines
     in the query_comment are replaced with " ". This allows the default
     query_comment to be added to `create external table` statements.

--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional, Set 
+from typing import Dict, Optional, Set
 
 from dbt.adapters.base.relation import BaseRelation, InformationSchema, Policy
 
@@ -15,6 +15,7 @@ class AthenaIncludePolicy(Policy):
 class AthenaRelation(BaseRelation):
     quote_character: str = ""
     include_policy: Policy = AthenaIncludePolicy()
+
 
 class AthenaSchemaSearchMap(Dict[InformationSchema, Dict[str, Set[Optional[str]]]]):
     """A utility class to keep track of what information_schema tables to

--- a/dbt/adapters/athena/session.py
+++ b/dbt/adapters/athena/session.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+import boto3.session
+from dbt.contracts.connection import Connection
+
+
+__BOTO3_SESSION__: Optional[boto3.session.Session] = None
+
+
+def get_boto3_session(connection: Connection = None) -> boto3.session.Session:
+    def init_session():
+        global __BOTO3_SESSION__
+        __BOTO3_SESSION__ = boto3.session.Session(
+            region_name=connection.credentials.region_name,
+            profile_name=connection.credentials.aws_profile_name,
+        )
+
+    if not __BOTO3_SESSION__:
+        if connection is None:
+            raise RuntimeError(
+                'A Connection object needs to be passed to initialize the boto3 session for the first time'
+            )
+        init_session()
+
+    return __BOTO3_SESSION__

--- a/dbt/include/athena/macros/adapters/columns.sql
+++ b/dbt/include/athena/macros/adapters/columns.sql
@@ -20,3 +20,41 @@
   {% set table = load_result('get_columns_in_relation').table %}
   {% do return(sql_convert_columns_in_relation(table)) %}
 {% endmacro %}
+
+{% macro alter_relation_add_columns(relation, add_columns = none) -%}
+  {% if add_columns is none %}
+    {% set add_columns = [] %}
+  {% endif %}
+
+  {% set sql -%}
+      alter {{ relation.type }} {{ relation }}
+          add columns (
+            {%- for column in add_columns -%}
+                {{ column.name }} {{ column.data_type }}{{ ', ' if not loop.last }}
+            {%- endfor -%}
+          )
+  {%- endset -%}
+
+  {% if (add_columns | length) > 0 %}
+    {{ return(run_query(sql)) }}
+  {% endif %}
+{% endmacro %}
+
+{% macro alter_relation_replace_columns(relation, replace_columns = none) -%}
+  {% if replace_columns is none %}
+    {% set replace_columns = [] %}
+  {% endif %}
+
+  {% set sql -%}
+      alter {{ relation.type }} {{ relation }}
+          replace columns (
+            {%- for column in replace_columns -%}
+                {{ column.name }} {{ column.data_type }}{{ ', ' if not loop.last }}
+            {%- endfor -%}
+          )
+  {%- endset -%}
+
+  {% if (replace_columns | length) > 0 %}
+    {{ return(run_query(sql)) }}
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/athena/macros/adapters/metadata.sql
+++ b/dbt/include/athena/macros/adapters/metadata.sql
@@ -17,7 +17,6 @@
                             else table_type
                         end as table_type,
 
-                        null as table_owner,
                         null as table_comment
 
                     from {{ information_schema }}.tables
@@ -54,8 +53,7 @@
                         columns.column_name,
                         columns.column_index,
                         columns.column_type,
-                        columns.column_comment,
-                        tables.table_owner
+                        columns.column_comment
 
                     from tables
                     join columns

--- a/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
@@ -40,6 +40,8 @@
         {%- set value = "'" + col + "'" -%}
       {%- elif column_type == 'date' -%}
         {%- set value = "'" + col|string + "'" -%}
+      {%- elif column_type == 'timestamp' -%}
+        {%- set value = "'" + col|string + "'" -%}
       {%- else -%}
         {%- do exceptions.raise_compiler_error('Need to add support for column type ' + column_type) -%}
       {%- endif -%}

--- a/dbt/include/athena/macros/materializations/models/incremental/on_schema_change.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/on_schema_change.sql
@@ -1,0 +1,27 @@
+{% macro sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}
+  {%- set partitioned_by = config.get('partitioned_by', default=none) -%}
+  {%- if partitioned_by is none -%}
+      {%- set partitioned_by = [] -%}
+  {%- endif %}
+  {%- set add_to_target_arr = schema_changes_dict['source_not_in_target'] -%}
+  {%- set replace_with_target_arr = remove_partitions_from_columns(schema_changes_dict['source_columns'], partitioned_by) -%}
+  {%- if on_schema_change == 'append_new_columns'-%}
+     {%- if add_to_target_arr | length > 0 -%}
+       {%- do alter_relation_add_columns(target_relation, add_to_target_arr) -%}
+     {%- endif -%}
+  {% elif on_schema_change == 'sync_all_columns' %}
+     {%- set remove_from_target_arr = schema_changes_dict['target_not_in_source'] -%}
+     {%- set new_target_types = schema_changes_dict['new_target_types'] -%}
+     {% if add_to_target_arr | length > 0 or remove_from_target_arr | length > 0 or new_target_types | length > 0 %}
+       {%- do alter_relation_replace_columns(target_relation, replace_with_target_arr) -%}
+     {% endif %}
+  {% endif %}
+  {% set schema_change_message %}
+    In {{ target_relation }}:
+        Schema change approach: {{ on_schema_change }}
+        Columns added: {{ add_to_target_arr }}
+        Columns removed: {{ remove_from_target_arr }}
+        Data types changed: {{ new_target_types }}
+  {% endset %}
+  {% do log(schema_change_message) %}
+{% endmacro %}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 package_name = "dbt-athena-community"
 
 dbt_version = "1.0"
-package_version = "1.0.2"
+package_version = "1.0.3"
 description = """The athena adapter plugin for dbt (data build tool)"""
 
 if not package_version.startswith(dbt_version):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(this_directory, 'README.md')) as f:
 package_name = "dbt-athena-community"
 
 dbt_version = "1.0"
-package_version = "1.0.3"
+package_version = "1.0.4"
 description = """The athena adapter plugin for dbt (data build tool)"""
 
 if not package_version.startswith(dbt_version):


### PR DESCRIPTION
This PR was originally created by @hiro-o918 over at: https://github.com/Tomme/dbt-athena/pull/114

**Problem**

Currently, dbt-athena does not support on_schema_change option.
closes https://github.com/Tomme/dbt-athena/issues/47

**Solution**

- Add custom column class AthenaColumn


Athena has different column type between DML and DDL (e.g. integer)

- https://docs.aws.amazon.com/athena/latest/ug/data-types.html

To avoid error on alter table statement because of difference of column type

- Overwrite macro sync_column_schemas

Athena does not support drop columns statement, but replace columns

- https://docs.aws.amazon.com/athena/latest/ug/alter-table-replace-columns.html

this causes inconsistency with original sync_column_schemas, so overwrite this macro on this adaptor