### PR TITLE
Feature/table iceberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ _Additional information_
   * The compression type to use for any storage format that allows compression to be specified. To see which options are available, check out [CREATE TABLE AS][create-table-as]
 * `field_delimiter` (`default=none`)
   * Custom field delimiter, for when format is set to `TEXTFILE`
+* `table_properties`: table properties to add to the table, valid for Iceberg only
+* `strict_location` (`default=True`): when working with iceberg it's possible to rename tables, in order to do so, tables need to avoid to have same location. Setting up `strict_location` to *false* allow a table creation on an unique location
 
 More information: [CREATE TABLE AS][create-table-as]
 
@@ -117,6 +119,34 @@ Support for incremental models:
 Due to the nature of AWS Athena, not all core dbt functionality is supported.
 The following features of dbt are not implemented on Athena:
 * Snapshots
+
+#### Iceberg
+The adapter support table materialization for Iceberg.
+
+To get started just add this as your model:
+```
+{{ config(
+    materialized='table',
+    format='iceberg',
+    partitioned_by=['bucket(5, user_id)'],
+    strict_location=false,
+    table_properties={
+    	'optimize_rewrite_delete_file_threshold': '2'
+    	}
+) }}
+
+SELECT
+	'A' AS user_id,
+	'pi' AS name,
+	'active' AS status,
+	17.89 AS cost,
+	1 AS quantity,
+	100000000 AS quantity_big,
+	current_date AS my_date
+```
+
+Iceberg support bucketing as hidden partitions, therefore use the `partitioned_by` config to add specific bucketing conditions.
+
 
 #### Known issues
 

--- a/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
@@ -6,8 +6,6 @@
   {%- set external_location = config.get('external_location', default=none) -%}
   {%- set staging_location = config.get('staging_location') -%}
   {%- set partitioned_by = config.get('partitioned_by', default=none) -%}
-  {%- set bucketed_by = config.get('bucketed_by', default=none) -%}
-  {%- set bucket_count = config.get('bucket_count', default=none) -%}
   {%- set write_compression = config.get('write_compression', default=none) -%}
 
   {%- set target_relation = this.incorporate(type='table') -%}

--- a/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
@@ -1,0 +1,112 @@
+{% macro drop_iceberg(relation) -%}
+  drop table if exists {{ relation }}
+{% endmacro %}
+
+{% macro create_table_iceberg(relation, old_relation, tmp_relation, sql) -%}
+  {%- set external_location = config.get('external_location', default=none) -%}
+  {%- set staging_location = config.get('staging_location') -%}
+  {%- set partitioned_by = config.get('partitioned_by', default=none) -%}
+  {%- set bucketed_by = config.get('bucketed_by', default=none) -%}
+  {%- set bucket_count = config.get('bucket_count', default=none) -%}
+  {%- set write_compression = config.get('write_compression', default=none) -%}
+
+  {%- set target_relation = this.incorporate(type='table') -%}
+
+  {% if tmp_relation is not none %}
+     {% do adapter.drop_relation(tmp_relation) %}
+  {% endif %}
+
+  -- create tmp table
+  {% do run_query(create_tmp_table_iceberg(tmp_relation, sql, staging_location)) %}
+
+  -- get columns from tmp table to retrieve metadata
+  {%- set dest_columns = adapter.get_columns_in_relation(tmp_relation) -%}
+
+  -- drop old relation after tmp table is ready
+  {%- if old_relation is not none -%}
+  	{% do run_query(drop_iceberg(old_relation)) %}
+  {%- endif -%}
+
+  -- create iceberg table
+  {% do run_query(create_iceberg_table_definition(target_relation, dest_columns)) %}
+
+  -- return final insert statement
+  {{ return(insert_from_sql(target_relation, sql)) }}
+
+{% endmacro %}
+
+
+{% macro create_tmp_table_iceberg(relation, sql, staging_location) -%}
+  create table
+    {{ relation }}
+    with (
+      write_compression='snappy',
+      format='parquet'
+    )
+  as
+    {{ sql }}
+    limit 0
+{% endmacro %}
+
+{% macro create_iceberg_table_definition(relation, dest_columns) -%}
+  {%- set external_location = config.get('external_location', default=none) -%}
+  {%- set strict_location = config.get('strict_location', default=true) -%}
+  {%- set partitioned_by = config.get('partitioned_by', default=none) -%}
+  {%- set table_properties = config.get('table_properties', default={}) -%}
+  {%- set _ = table_properties.update({'table_type': 'ICEBERG'}) -%}
+  {%- set table_properties_formatted = [] -%}
+  {%- set dest_columns_with_type = [] -%}
+
+  {%- for k in table_properties -%}
+  	{% set _ = table_properties_formatted.append("'" + k + "'='" + table_properties[k] + "'") -%}
+  {%- endfor -%}
+
+  {%- set table_properties_csv= table_properties_formatted | join(', ') -%}
+
+  {%- set external_location = adapter.s3_unique_location(external_location, strict_location, target.s3_staging_dir, relation.name) -%}
+
+  {%- for col in dest_columns -%}
+	{% set dtype = iceberg_data_type(col.dtype) -%}
+  	{% set _ = dest_columns_with_type.append(col.name + ' ' + dtype) -%}
+  {%- endfor -%}
+
+  {%- set dest_columns_with_type_csv = dest_columns_with_type | join(', ') -%}
+
+  CREATE TABLE {{ relation }} (
+    {{ dest_columns_with_type_csv }}
+  )
+  {%- if partitioned_by is not none %}
+    {%- set partitioned_by_csv = partitioned_by | join(', ') -%}
+  	PARTITIONED BY ({{partitioned_by_csv}})
+  {%- endif %}
+  LOCATION '{{ external_location }}'
+  TBLPROPERTIES (
+  	{{table_properties_csv}}
+  )
+{% endmacro %}
+
+
+{% macro insert_from_sql(target_relation, sql, statement_name="main") %}
+  {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+  {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
+
+  insert into {{ target_relation }} ({{ dest_cols_csv }}) (
+    select {{ dest_cols_csv }}
+    from (
+      {{sql}}
+      )
+    );
+{%- endmacro %}
+
+
+{% macro iceberg_data_type(col_type) -%}
+  {%- if 'varchar' in col_type -%}
+    {% set data_type = 'string' -%}
+  {%- elif 'integer' == col_type -%}
+     {% set data_type = 'int' -%}
+  {%- else -%}
+     {% set data_type = col_type -%}
+  {%- endif -%}
+
+  {{ return(data_type) }}
+{% endmacro %}

--- a/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
@@ -42,7 +42,9 @@
       format='parquet'
     )
   as
-    {{ sql }}
+    select * from (
+        {{ sql }}
+    )
     limit 0
 {% endmacro %}
 

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -1,6 +1,7 @@
 {% materialization table, adapter='athena' -%}
   {%- set identifier = model['alias'] -%}
 
+  {%- set format = config.get('format', default='parquet') -%}
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
@@ -10,16 +11,31 @@
   {{ run_hooks(pre_hooks) }}
 
   {%- if old_relation is not none -%}
+    {%- if format != 'iceberg' -%}
       {{ adapter.drop_relation(old_relation) }}
+    {%- endif -%}
   {%- endif -%}
 
-  -- build model
-  {% call statement('main') -%}
-    {{ create_table_as(False, target_relation, sql) }}
-  {% endcall -%}
+  {%- if format == 'iceberg' -%}
+    {%- set tmp_relation = make_temp_relation(target_relation) -%}
+	{%- set build_sql = create_table_iceberg(target_relation, old_relation, tmp_relation, sql) -%}
+  {% else %}
+    {% set build_sql = create_table_as(False, target_relation, sql) -%}
+  {%- endif -%}
+
+  {% call statement("main") %}
+    {{ build_sql }}
+  {% endcall %}
+
+  -- drop tmp table in case of iceberg
+  {%- if format == 'iceberg' -%}
+  	{% do adapter.drop_relation(tmp_relation) %}
+  {%- endif -%}
 
   -- set table properties
-  {{ set_table_classification(target_relation, 'parquet') }}
+  {%- if format != 'iceberg' -%}
+    {{ set_table_classification(target_relation, 'parquet') }}
+  {%- endif -%}
 
   {{ run_hooks(post_hooks) }}
 


### PR DESCRIPTION
# What
This PR introduce iceberg as table materialization.

As iceberg doesn't support CTA, the implementation do the following:
* create tmp table as parquet with limit 0
* drop the old table, if exist
* create iceberg table based on tmp table definition, only metadata
* insert into from tmp sql
* drop tmp table

## Notes
* ` adapter.drop_relation` doesn't work with iceberg, a drop statement of iceberg table lead to deleting the data in S3 automatically in the specified location
* ~[table properties](https://docs.amazonaws.cn/en_us/athena/latest/ug/querying-iceberg-creating-tables.html#querying-iceberg-table-properties) are yet not supported, easy to add later on.~) Added in this PR, see test examples.
* It's possible to enable an unique location to your table adding this config
<pre>
{{ config(
    external_location='s3://bucket/example_iceberg/',
    strict_location=False
) }}
</pre>
Doing so, the adapter add a unique uuid to the final table location, that is help-full in case of rename statement (e.g. you want to promote the table to your table used by analyst/reporting, after some running some dbt tests), to avoid collision when the table is recreated. It's possible to disable such behaviour using `strict_location=True`, that is the default.


## Models used to test

#### Without partitions
<pre>
{{ config(
    materialized='table',
    format='iceberg'
) }}


SELECT 'A' AS user_id, 'pi' AS name, 'active' AS status, 17.89 AS amount, 1 as quantity
UNION ALL
SELECT 'B' AS user_id, 'sh' AS name, 'active' AS status, 1 AS amount, 10000 as quantity
UNION ALL
SELECT 'C' AS user_id, 'zh' AS name, 'not_active' AS status, 20.54 AS amount, 340000 as quantity

</pre>

### With partitions

<pre>
{{ config(
    materialized='table',
    format='iceberg',
    partitioned_by=['status']
) }}


SELECT 'A' AS user_id, 'pi' AS name, 'active' AS status, 17.89 AS amount, 1 as quantity
UNION ALL
SELECT 'B' AS user_id, 'sh' AS name, 'active' AS status, 1 AS amount, 10000 as quantity
UNION ALL
SELECT 'C' AS user_id, 'zh' AS name, 'not_active' AS status, 20.54 AS amount, 340000 as quantity

</pre>


### With external location

<pre>
{{ config(
    materialized='table',
    format='iceberg',
    external_location='s3://my_bucket/my_table/'
) }}


SELECT 'A' AS user_id, 'pi' AS name, 'active' AS status, 17.89 AS amount, 1 as quantity
UNION ALL
SELECT 'B' AS user_id, 'sh' AS name, 'active' AS status, 1 AS amount, 10000 as quantity
UNION ALL
SELECT 'C' AS user_id, 'zh' AS name, 'not_active' AS status, 20.54 AS amount, 340000 as quantity

</pre>

### With different data types
<pre>
{{ config(
    materialized='table',
    format='iceberg',
    partitioned_by=['status']
) }}


SELECT
	'A' AS user_id,
	'pi' AS name,
	'active' AS status,
	17.89 AS cost,
	1 AS quantity,
	100000000 AS quantity_big,
	current_date AS my_date,
	cast(current_timestamp as timestamp) AS my_timestamp
</pre>

### Table properties
<pre>
{{ config(
    materialized='table',
    format='iceberg',
    partitioned_by=['status'],
    table_properties={
    	'write_target_data_file_size_bytes': '134217728',
    	'optimize_rewrite_delete_file_threshold': '2'
    	}
) }}


SELECT
	'A' AS user_id,
	'pi' AS name,
	'active' AS status,
	17.89 AS cost,
	1 AS quantity,
	100000000 AS quantity_big,
	current_date AS my_date,
	cast(current_timestamp as timestamp) AS my_timestamp
</pre>

### Not strict location
<pre>
{{ config(
    materialized='table',
    format='iceberg',
    partitioned_by=['status'],
    external_location='s3://my_bucket/silver_athena/example_iceberg/',
    strict_location=False,
    table_properties={
    	'optimize_rewrite_delete_file_threshold': '2'
    	}
) }}

SELECT
	'A' AS user_id,
	'pi' AS name,
	'active' AS status,
	17.89 AS cost,
	1 AS quantity,
	100000000 AS quantity_big,
	current_date AS my_date,
	cast(current_timestamp as timestamp) AS my_timestamp

</pre>