### PR TITLE
Fix edge case on Iceberg types

### DIFF
--- a/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
@@ -111,8 +111,8 @@
   {% set data_type = ns.iceberg_type -%}
 
   -- treat all varchar columns without length as string
-  {%- if data_type == 'varchar' -%}
-    {% set data_type = 'string' -%}
+  {%- if 'varchar' in data_type -%}
+    {% set data_type = col_type.replace('varchar', 'string') -%}
   {%- endif -%}
 
   -- transform array and map

--- a/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
@@ -110,6 +110,11 @@
 
   {% set data_type = ns.iceberg_type -%}
 
+  -- treat all varchar columns without length as string
+  {%- if data_type == 'varchar' -%}
+    {% set data_type = 'string' -%}
+  {%- endif -%}
+
   -- transform array and map
   {%- if 'array' in data_type or 'map' in data_type -%}
     {% set data_type = data_type.replace('(', '<').replace(')', '>') -%}
@@ -119,6 +124,8 @@
   {%- if 'integer' in data_type -%}
     {% set data_type = data_type.replace('integer', 'int') -%}
   {%- endif -%}
+
+  {{print(col_type)}}
 
   {{ return(data_type) }}
 {% endmacro %}

--- a/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
@@ -125,7 +125,5 @@
     {% set data_type = data_type.replace('integer', 'int') -%}
   {%- endif -%}
 
-  {{print(col_type)}}
-
   {{ return(data_type) }}
 {% endmacro %}

--- a/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
@@ -100,20 +100,9 @@
 
 
 {% macro iceberg_data_type(col_type) -%}
-    -- transform varchar
+    -- replace varchar with string
   {% set re = modules.re %}
-  {% set ns = namespace(iceberg_type=col_type) %}
-  {% set matching_strings = re.findall('varchar\(\d+\)', ns.iceberg_type) %}
-  {% for varchar_part in matching_strings %}
-    {% set ns.iceberg_type = ns.iceberg_type.replace(varchar_part, 'string') %}
-  {% endfor %}
-
-  {% set data_type = ns.iceberg_type -%}
-
-  -- treat all varchar columns without length as string
-  {%- if 'varchar' in data_type -%}
-    {% set data_type = col_type.replace('varchar', 'string') -%}
-  {%- endif -%}
+  {% set data_type = re.sub('varchar(?:\(\d+\))?', 'string',  col_type) %}
 
   -- transform array and map
   {%- if 'array' in data_type or 'map' in data_type -%}


### PR DESCRIPTION
# What

When running this model:

```
{{ config(
    materialized='table',
    format='iceberg',
    schema='silver'
) }}

SELECT
    'abc' AS test_string
    , true AS test_bool
    , 123 AS test_int
    , 123.45 AS test_float
    , CAST(1234.567 AS DECIMAL(7, 3)) AS test_decimal
    , CAST(34 AS BIGINT) AS test_bigint
    , CAST(123.33 AS DOUBLE) AS test_double
    , ARRAY['a'] AS test_array_string
    , ARRAY[1] AS test_array_int
    , ARRAY[false] AS test_array_bool
    , MAP(ARRAY['a'], ARRAY[1]) AS test_map_string_int
    , MAP(ARRAY['a'], ARRAY['b']) AS test_map_string_string
    , MAP(ARRAY['a'], ARRAY[true]) AS test_map_string_bool
    , MAP(ARRAY[1], ARRAY['a']) AS test_map_int_string
    , MAP(ARRAY[1], ARRAY[1]) AS test_map_int_int
    , MAP(ARRAY[true], ARRAY['a']) AS test_map_bool_string
    , MAP(ARRAY[ARRAY['a']], ARRAY['a']) AS test_map_arrstring_string
    , CAST('2022-01-01' AS date) AS test_date
    , CAST('2022-01-01 00:00:00' AS timestamp(3)) AS test_timestamp
``` 
all run fine.

But when running 
```SELECT
    test_string,
    test_bool,
    test_int,
    test_float,
    test_decimal,
    test_bigint,
    test_double,
    test_array_string,
    test_array_int,
    test_array_bool,
    test_map_string_int,
    test_map_string_string,
    test_map_string_bool,
    test_map_int_string,
    test_map_int_int,
    test_map_bool_string,
    test_map_arrstring_string,
    test_date,
    cast(test_timestamp as timestamp(3)) as test_timestamp
FROM {{ref('test_iceberg')}}``` 
there are columns types were somehow athena store the type as `varchar` without length, to failure as not supported. This PR add another condition that check for strict varchar values and replace with string.
Note that to make this working I had to cast the timestamp to timestamp(3), otherwise it won't work. 

