### PR TITLE
fix: multi-thread issues by removing global boto3 session

### DIFF
--- a/dbt/adapters/athena/session.py
+++ b/dbt/adapters/athena/session.py
@@ -2,10 +2,7 @@ import boto3.session
 from dbt.contracts.connection import Connection
 
 
-def get_boto3_session(connection: Connection = None) -> boto3.session.Session:
-    if connection is None:
-        raise RuntimeError("A Connection object needs to be passed to initialize the boto3 session")
-
+def get_boto3_session(connection: Connection) -> boto3.session.Session:
     return boto3.session.Session(
         region_name=connection.credentials.region_name,
         profile_name=connection.credentials.aws_profile_name,

--- a/dbt/adapters/athena/session.py
+++ b/dbt/adapters/athena/session.py
@@ -1,24 +1,12 @@
-from typing import Optional
-
 import boto3.session
 from dbt.contracts.connection import Connection
 
-__BOTO3_SESSION__: Optional[boto3.session.Session] = None
-
 
 def get_boto3_session(connection: Connection = None) -> boto3.session.Session:
-    def init_session():
-        global __BOTO3_SESSION__
-        __BOTO3_SESSION__ = boto3.session.Session(
-            region_name=connection.credentials.region_name,
-            profile_name=connection.credentials.aws_profile_name,
-        )
+    if connection is None:
+        raise RuntimeError("A Connection object needs to be passed to initialize the boto3 session")
 
-    if not __BOTO3_SESSION__:
-        if connection is None:
-            raise RuntimeError(
-                "A Connection object needs to be passed to initialize the boto3 session for the first time"
-            )
-        init_session()
-
-    return __BOTO3_SESSION__
+    return boto3.session.Session(
+        region_name=connection.credentials.region_name,
+        profile_name=connection.credentials.aws_profile_name,
+    )


### PR DESCRIPTION
I run a dbt project usually with `threads: 4` or `threads: 8`. When I switched my projects away from the `Tomme/dbt-athena` to this adapter, I received:

```
18:29:33.190966 [info ] [MainThread]: Found 79 models, 9 tests, 0 snapshots, 0 analyses, 510 macros, 0 operations, 0 seed files, 64 sources, 0 exposures, 0 metrics
18:29:33.193761 [info ] [MainThread]: 
18:29:33.194168 [debug] [MainThread]: Acquiring new athena connection "master"
18:29:33.197412 [debug] [ThreadPool]: Acquiring new athena connection "list_awsdatacatalog"
18:29:33.198456 [debug] [ThreadPool]: Acquiring new athena connection "list_awsdatacatalog"
18:29:33.198652 [debug] [ThreadPool]: Acquiring new athena connection "list_awsdatacatalog"
18:29:33.198835 [debug] [ThreadPool]: Acquiring new athena connection "list_awsdatacatalog"
18:29:33.199121 [debug] [ThreadPool]: Opening a new connection, currently in state init
18:29:33.202800 [debug] [ThreadPool]: Acquiring new athena connection "list_awsdatacatalog"
18:29:33.203007 [debug] [ThreadPool]: Opening a new connection, currently in state init
18:29:33.236405 [debug] [ThreadPool]: Opening a new connection, currently in state init
18:29:33.243815 [debug] [ThreadPool]: Opening a new connection, currently in state init
18:29:33.249740 [debug] [ThreadPool]: Opening a new connection, currently in state init
18:29:33.250769 [error] [ThreadPool]: Athena adapter: Got an error when attempting to open a Athena connection due to 'credential_provider'
Traceback (most recent call last):
  File "/Users/jesse.dobbelaere/Code/side-projects/dbt-athena/dbt/adapters/athena/connections.py", line 155, in open
    handle = AthenaConnection(
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/pyathena/connection.py", line 139, in __init__
    self._client = self._session.client(
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/boto3/session.py", line 299, in client
    return self._session.create_client(
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/botocore/session.py", line 951, in create_client
    credentials = self.get_credentials()
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/botocore/session.py", line 507, in get_credentials
    self._credentials = self._components.get_component(
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/botocore/session.py", line 1112, in get_component
    del self._deferred[name]
KeyError: 'credential_provider'
```

I did some investigation in #43 and found that the global session we use (singleton) is probably the culprit. Each thread needs its own session. Re-using a session is not thread-safe. 

This is nicely mentioned on the documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html#multithreading-or-multiprocessing-with-resources

> ...each thread would have its own Boto3 session...

Therefore, let's remove the global session and then each thread will make a new `AthenaConnection` (with a new session)?

Fixes #43 