### PR TITLE
Fix default incremental strategy

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -267,3 +267,6 @@ class AthenaAdapter(SQLAdapter):
                 )
 
         return relations
+
+    def valid_incremental_strategies(self):
+        return ["append", "insert_overwrite"]

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -267,6 +267,3 @@ class AthenaAdapter(SQLAdapter):
                 )
 
         return relations
-
-    def valid_incremental_strategies(self):
-        return ["append", "insert_overwrite"]

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -8,7 +8,7 @@
     {% do exceptions.raise_compiler_error(overwrite_msg) %}
   {% endif %}
 
-  {% set raw_strategy = config.get('incremental_strategy', default='insert_overwrite') %}
+  {% set raw_strategy = config.get('incremental_strategy') or 'insert_overwrite' %}
   {% set strategy = validate_get_incremental_strategy(raw_strategy) %}
 
   {% set partitioned_by = config.get('partitioned_by', default=none) %}


### PR DESCRIPTION
Fixes #42 

This was caused by a refactor of the incremental materialization in dbt core 1.3: https://github.com/dbt-labs/dbt-core/pull/5359/files

* ✅ I added an implementation of the supported incremental strategies (see PR above that introduced it in dbt 1.3)
* ✅ I use a default in a slightly different way, but same as how snowflake and bigquery adapter do it: 
  * https://github.com/dbt-labs/dbt-snowflake/blob/22a0ac6701da6d7b9c4f009e23c0a58a9fdc7641/dbt/include/snowflake/macros/materializations/incremental.sql#L32
  * https://github.com/dbt-labs/dbt-bigquery/pull/223/files#diff-167e3557df7f18f1520c5db0045dfac9923e38a617c909d703be844192b28ebeR17

In the long term we should probably refactor the `incremental.sql` and provide strategies macro's for each of them (with a 'default'). See here: https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/include/global_project/macros/materializations/models/incremental/strategies.sql
But I felt that was out of scope for this fix. 