### PR TITLE
feat: add incremental append and merge for iceberg tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@
 * Supports [Seeds][seeds]
 * Correctly detects views and their columns
 * Support [incremental models][incremental]
-  * Support two incremental update strategies: `insert_overwrite` and `append`
-  * Does **not** support the use of `unique_key`
-* **Only** supports Athena engine 2
-  * [Changing Athena Engine Versions][engine-change]
+  * On iceberg tables :
+    * Support the use of `unique_key` only with query engine `v3` using the `merge` strategy
+    * Support the `append` strategy
+  * On Hive tables :
+    * Support two incremental update strategies: `insert_overwrite` and `append`
+    * Does **not** support the use of `unique_key`
 * Does not support [Python models][python-models]
 
 [seeds]: https://docs.getdbt.com/docs/building-a-dbt-project/seeds
 [incremental]: https://docs.getdbt.com/docs/building-a-dbt-project/building-models/configuring-incremental-models
-[engine-change]: https://docs.aws.amazon.com/athena/latest/ug/engine-versions-changing.html
 [python-models]: https://docs.getdbt.com/docs/build/python-models#configuring-python-models
 
 ### Installation
@@ -47,18 +48,18 @@ stored login info. You can configure the AWS profile name to use via `aws_profil
 
 A dbt profile can be configured to run against AWS Athena using the following configuration:
 
-| Option          | Description                                                                    | Required?  | Example               |
-|---------------- |--------------------------------------------------------------------------------|----------- |-----------------------|
-| s3_staging_dir  | S3 location to store Athena query results and metadata                         | Required   | `s3://bucket/dbt/`    |
-| s3_data_dir     | Prefix for storing tables, if different from the connection's `s3_staging_dir` | Optional   | `s3://bucket2/dbt/`   |
-| s3_data_naming  | How to generate table paths in `s3_data_dir`                                   | Optional   | `schema_table_unique` |
-| region_name     | AWS region of your Athena instance                                             | Required   | `eu-west-1`           |
-| schema          | Specify the schema (Athena database) to build models into (lowercase **only**) | Required   | `dbt`                 |
-| database        | Specify the database (Data catalog) to build models into (lowercase **only**)  | Required   | `awsdatacatalog`      |
-| poll_interval   | Interval in seconds to use for polling the status of query results in Athena   | Optional   | `5`                   |
-| aws_profile_name| Profile to use from your AWS shared credentials file.                          | Optional   | `my-profile`          |
-| work_group| Identifier of Athena workgroup                                                 | Optional   | `my-custom-workgroup` |
-| num_retries| Number of times to retry a failing query                                       | Optional  | `3`                   | `5`
+| Option           | Description                                                                    | Required?   | Example               |
+|------------------|--------------------------------------------------------------------------------|-------------|-----------------------|
+| s3_staging_dir   | S3 location to store Athena query results and metadata                         | Required    | `s3://bucket/dbt/`    |
+| s3_data_dir      | Prefix for storing tables, if different from the connection's `s3_staging_dir` | Optional    | `s3://bucket2/dbt/`   |
+| s3_data_naming   | How to generate table paths in `s3_data_dir`                                   | Optional    | `schema_table_unique` |
+| region_name      | AWS region of your Athena instance                                             | Required    | `eu-west-1`           |
+| schema           | Specify the schema (Athena database) to build models into (lowercase **only**) | Required    | `dbt`                 |
+| database         | Specify the database (Data catalog) to build models into (lowercase **only**)  | Required    | `awsdatacatalog`      |
+| poll_interval    | Interval in seconds to use for polling the status of query results in Athena   | Optional    | `5`                   |
+| aws_profile_name | Profile to use from your AWS shared credentials file.                          | Optional    | `my-profile`          |
+| work_group       | Identifier of Athena workgroup                                                 | Optional    | `my-custom-workgroup` |
+| num_retries      | Number of times to retry a failing query                                       | Optional    | `3`                   |
 
 
 **Example profiles.yml entry:**
@@ -196,8 +197,6 @@ The following features of dbt are not implemented on Athena:
   ```
 
 * Tables, schemas and database should only be lowercase
-* **Only** supports Athena engine 2
-  * [Changing Athena Engine Versions][engine-change]
 
 ### Contributing
 

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -39,7 +39,6 @@ logger = AdapterLogger("Athena")
 class AthenaCredentials(Credentials):
     s3_staging_dir: str
     region_name: str
-    schema: str
     endpoint_url: Optional[str] = None
     work_group: Optional[str] = None
     aws_profile_name: Optional[str] = None
@@ -66,7 +65,7 @@ class AthenaCredentials(Credentials):
             "schema",
             "poll_interval",
             "aws_profile_name",
-            "endpoing_url",
+            "endpoint_url",
             "s3_data_dir",
             "s3_data_naming",
         )

--- a/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers_iceberg.sql
@@ -10,6 +10,7 @@
 
   {%- set target_relation = this.incorporate(type='table') -%}
 
+  -- clean residual tmp table
   {% if tmp_relation is not none %}
      {% do adapter.drop_relation(tmp_relation) %}
   {% endif %}
@@ -33,8 +34,7 @@
 
 {% endmacro %}
 
-
-{% macro create_tmp_table_iceberg(relation, sql, staging_location) -%}
+{% macro create_tmp_table_iceberg(relation, sql, staging_location, with_limit=true) -%}
   create table
     {{ relation }}
     with (
@@ -45,7 +45,9 @@
     select * from (
         {{ sql }}
     )
-    limit 0
+    {%- if with_limit -%}
+      limit 0
+    {%- endif -%}
 {% endmacro %}
 
 {% macro create_iceberg_table_definition(relation, dest_columns) -%}

--- a/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
@@ -1,11 +1,21 @@
-{% macro validate_get_incremental_strategy(raw_strategy) %}
-  {% set invalid_strategy_msg -%}
-    Invalid incremental strategy provided: {{ raw_strategy }}
-    Expected one of: 'append', 'insert_overwrite'
-  {%- endset %}
+{% macro validate_get_incremental_strategy(raw_strategy, format) %}
+  {%- if format == 'iceberg' -%}
+    {% set invalid_strategy_msg -%}
+      Invalid incremental strategy provided: {{ raw_strategy }}
+      Incremental models on Iceberg tables only work with 'append' or 'merge' (v3 only) strategy.
+    {%- endset %}
+    {% if raw_strategy not in ['append', 'merge'] %}
+      {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+    {% endif %}
+  {%- else -%}
+    {% set invalid_strategy_msg -%}
+      Invalid incremental strategy provided: {{ raw_strategy }}
+      Expected one of: 'append', 'insert_overwrite'
+    {%- endset %}
 
-  {% if raw_strategy not in ['append', 'insert_overwrite'] %}
-    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+    {% if raw_strategy not in ['append', 'insert_overwrite'] %}
+      {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
+    {% endif %}
   {% endif %}
 
   {% do return(raw_strategy) %}

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -1,18 +1,12 @@
 {% materialization incremental, adapter='athena' -%}
 
-  {% set unique_key = config.get('unique_key') %}
-  {% set overwrite_msg -%}
-    Athena adapter does not support 'unique_key'
-  {%- endset %}
-  {% if unique_key is not none %}
-    {% do exceptions.raise_compiler_error(overwrite_msg) %}
-  {% endif %}
-
   {% set raw_strategy = config.get('incremental_strategy') or 'insert_overwrite' %}
-  {% set strategy = validate_get_incremental_strategy(raw_strategy) %}
+  {% set format = config.get('format', default='parquet') %}
+  {% set strategy = validate_get_incremental_strategy(raw_strategy, format) %}
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
 
   {% set partitioned_by = config.get('partitioned_by', default=none) %}
+  {% set staging_location = config.get('staging_location') %}
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
   {% set tmp_relation = make_temp_relation(this) %}
@@ -22,33 +16,75 @@
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
+  -- Having Iceberg in v2 engine not able to do CTAS makes it complex. Hard to factorize with table materialization
+  -- because of statement block.
+  {%- if format == 'iceberg' -%}
+    {%- set iceberg_tmp_relation = make_temp_relation(target_relation, '__incremental_iceberg_ctas') -%}
+  {%- endif -%}
+
   {% set to_drop = [] %}
   {% if existing_relation is none %}
-      {% set build_sql = create_table_as(False, target_relation, sql) %}
+    {%- if format == 'iceberg' -%}
+      {%- set build_sql = create_table_iceberg(target_relation, existing_relation, iceberg_tmp_relation, sql) -%}
+      {% do to_drop.append(iceberg_tmp_relation) %}
+    {% else %}
+      {% set build_sql = create_table_as(False, target_relation, sql) -%}
+    {%- endif -%}
   {% elif existing_relation.is_view or should_full_refresh() %}
-      {% do adapter.drop_relation(existing_relation) %}
-      {% set build_sql = create_table_as(False, target_relation, sql) %}
+    {% do adapter.drop_relation(existing_relation) %}
+    {%- if format == 'iceberg' -%}
+      {%- set build_sql = create_table_iceberg(target_relation, existing_relation, iceberg_tmp_relation, sql) -%}
+      {% do to_drop.append(iceberg_tmp_relation) %}
+    {% else %}
+      {% set build_sql = create_table_as(False, target_relation, sql) -%}
+    {%- endif -%}
   {% elif partitioned_by is not none and strategy == 'insert_overwrite' %}
       {% set tmp_relation = make_temp_relation(target_relation) %}
       {% if tmp_relation is not none %}
-          {% do adapter.drop_relation(tmp_relation) %}
+        {% do adapter.drop_relation(tmp_relation) %}
       {% endif %}
       {% do run_query(create_table_as(True, tmp_relation, sql)) %}
       {% do delete_overlapping_partitions(target_relation, tmp_relation, partitioned_by) %}
       {% set build_sql = incremental_insert(on_schema_change, tmp_relation, target_relation, existing_relation) %}
       {% do to_drop.append(tmp_relation) %}
-  {% else %}
+  {% elif strategy == 'append' %}
       {% set tmp_relation = make_temp_relation(target_relation) %}
       {% if tmp_relation is not none %}
-          {% do adapter.drop_relation(tmp_relation) %}
+        {% do adapter.drop_relation(tmp_relation) %}
       {% endif %}
-      {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+      {%- if format == 'iceberg' -%}
+         -- We need to use the create_tmp_table_iceberg macro (parquet table) because create_table_as create a table
+         -- with the format inherited from config. For Iceberg, what we are doing is that we create a parquet table
+         -- containing the result of the incremental query (no limit), and then we insert this in the iceberg table.
+        {% do run_query(create_tmp_table_iceberg(tmp_relation, sql, staging_location, false)) %}
+      {% else %}
+        {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+      {%- endif -%}
       {% set build_sql = incremental_insert(on_schema_change, tmp_relation, target_relation, existing_relation) %}
       {% do to_drop.append(tmp_relation) %}
+  {% elif strategy == 'merge' and format == 'iceberg' %}
+    -- Merge is only supported for Iceberg in v3 engine. In this scenario, we are going to start the same as the append
+    -- strategy, meaning creating a temp table with the incremental query and then, instead of inserting, we are
+    -- merging
+    {% set unique_key = config.get('unique_key') %}
+    {% set empty_unique_key -%}
+      Merge strategy must implement unique_key as a single column or a list of columns.
+    {%- endset %}
+    {% if unique_key is none %}
+      {% do exceptions.raise_compiler_error(empty_unique_key) %}
+    {% endif %}
+
+    {% set tmp_relation = make_temp_relation(target_relation) %}
+    {% if tmp_relation is not none %}
+      {% do adapter.drop_relation(tmp_relation) %}
+    {% endif %}
+    {% do run_query(create_tmp_table_iceberg(tmp_relation, sql, staging_location, false)) %}
+    {% set build_sql = iceberg_merge(tmp_relation, target_relation, unique_key) %}
+    {% do to_drop.append(tmp_relation) %}
   {% endif %}
 
   {% call statement("main") %}
-      {{ build_sql }}
+    {{ build_sql }}
   {% endcall %}
 
   -- set table properties
@@ -64,7 +100,7 @@
   {% do adapter.commit() %}
 
   {% for rel in to_drop %}
-      {% do adapter.drop_relation(rel) %}
+    {% do adapter.drop_relation(rel) %}
   {% endfor %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}

--- a/dbt/include/athena/macros/materializations/models/incremental/merge.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/merge.sql
@@ -1,0 +1,34 @@
+{% macro iceberg_merge(tmp_relation, target_relation, unique_key, statement_name="main") %}
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
+    {% if unique_key is sequence and unique_key is not string %}
+      {%- set unique_key_cols = unique_key -%}
+    {% else %}
+      {%- set unique_key_cols = [unique_key] -%}
+    {% endif %}
+    {%- set src_columns = [] -%}
+    {%- set update_columns = [] -%}
+    {%- for col in dest_columns -%}
+      {%- do src_columns.append('src."' + col.name + '"') -%}
+      {% if col.name not in unique_key_cols %}
+        {%- do update_columns.append(col.name) -%}
+      {% endif %}
+    {%- endfor -%}
+    {%- set src_cols_csv = src_columns | join(', ') -%}
+
+    merge into {{ target_relation }} as target using {{ tmp_relation }} as src
+    ON (
+      {% for key in unique_key_cols %}
+        target.{{ key }} = src.{{ key }}
+        {{ "and " if not loop.last }}
+      {% endfor %}
+    )
+    when matched
+      then update set
+        {% for col in update_columns %}
+          {{ '"' + col + '"' }} = {{ 'src."' + col + '"' }} {{ "," if not loop.last }}
+        {% endfor %}
+    when not matched
+      then insert ({{ dest_cols_csv }})
+       values ({{ src_cols_csv }});
+{%- endmacro %}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -18,7 +18,7 @@
 
   {%- if format == 'iceberg' -%}
     {%- set tmp_relation = make_temp_relation(target_relation) -%}
-	{%- set build_sql = create_table_iceberg(target_relation, old_relation, tmp_relation, sql) -%}
+	  {%- set build_sql = create_table_iceberg(target_relation, old_relation, tmp_relation, sql) -%}
   {% else %}
     {% set build_sql = create_table_as(False, target_relation, sql) -%}
   {%- endif -%}


### PR DESCRIPTION
Now Iceberg tables support incremental models with `append` (for both v2 and v3) and `merge` (v3 only).

I added the specifications in the README.md.

I am also agree with a comment made in an other PR about splitting the incremental sql file according to dbt-core standard. Should we do this in this PR or in an other one ?