### PR TITLE
Adding user-agent-extra parameter to improve Log Analysis

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -5,7 +5,9 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, ContextManager, Dict, List, Optional, Tuple
 
+import pkg_resources
 import tenacity
+from botocore import config
 from dbt.adapters.base import Credentials
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.contracts.connection import AdapterResponse, Connection, ConnectionState
@@ -168,6 +170,10 @@ class AthenaConnectionManager(SQLConnectionManager):
                         "TooManyRequestsException",
                         "InternalServerException",
                     ),
+                ),
+                config=config.Config(
+                    user_agent_extra="dbt-athena-community/"
+                    + pkg_resources.get_distribution("dbt-athena-community").version
                 ),
             )
 


### PR DESCRIPTION
User-agent is key parameter to improve Log Analysis. Previously, dbt-athena users were not able to differentiate boto3 calls from dbt-athena calls. Introducing the user-agent-extra parameter to the PyAthena/boto3 connections allow users to identify HTTP calls from dbt-athena

Example of new user-agent:

`'User-Agent': b'Boto3/1.26.11 Python/3.7.10 Linux/4.14.296-222.539.amzn2.x86_64 Botocore/1.29.11 dbt-athena-community/1.3.1'`
