### PR TITLE
fix: incremental table with insert_overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,12 @@ or setting up the value for groups of model in dbt_project.yml
 Support for [incremental models](https://docs.getdbt.com/docs/build/incremental-models).
 
 These strategies are supported:
-* `insert_overwrite`
-* `append`
+
+* `insert_overwrite` (default): The insert overwrite strategy deletes the overlapping partitions from the destination
+table, and then inserts the new records from the source. This strategy depends on the `partitioned_by` keyword! If no
+partitions are defined, dbt will fall back to the `append` strategy.
+* `append`: Insert new records without updating, deleting or overwriting any existing data. There might be duplicate
+data (e.g. great for log or historical data).
 * `merge` in combination with `unique_key`, only available when using iceberg and an engine version v3
 
 #### On schema change
@@ -149,7 +153,7 @@ In detail, please refer to [dbt docs](https://docs.getdbt.com/docs/build/increme
 
 
 #### Iceberg
-The adapter support table materialization for Iceberg.
+The adapter supports table materialization for Iceberg.
 
 To get started just add this as your model:
 ```
@@ -172,7 +176,7 @@ SELECT
 	current_date AS my_date
 ```
 
-Iceberg support bucketing as hidden partitions, therefore use the `partitioned_by` config to add specific bucketing conditions.
+Iceberg supports bucketing as hidden partitions, therefore use the `partitioned_by` config to add specific bucketing conditions.
 
 It is possible to use iceberg in an incremental fashion, specifically 2 strategies are supported:
 * `append`: new records are appended to the table, this can lead to duplicates
@@ -233,5 +237,5 @@ make run_tests
 ### Helpful Resources
 
 * [Athena CREATE TABLE AS](https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html)
-* [fishtown-analytics/dbt](https://github.com/fishtown-analytics/dbt)
+* [dbt-labs/dbt-core](https://github.com/dbt-labs/dbt-core)
 * [laughingman7743/PyAthena](https://github.com/laughingman7743/PyAthena)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ table, and then inserts the new records from the source. This strategy depends o
 partitions are defined, dbt will fall back to the `append` strategy.
 * `append`: Insert new records without updating, deleting or overwriting any existing data. There might be duplicate
 data (e.g. great for log or historical data).
-* `merge` in combination with `unique_key`, only available when using iceberg and an engine version v3
+* `merge`: Conditionally updates, deletes, or inserts rows into an Iceberg table. Used in combination with `unique_key`.
+Only available when using Iceberg and Athena engine version 3.
 
 #### On schema change
 

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -81,6 +81,14 @@
     {% do run_query(create_tmp_table_iceberg(tmp_relation, sql, staging_location, false)) %}
     {% set build_sql = iceberg_merge(tmp_relation, target_relation, unique_key) %}
     {% do to_drop.append(tmp_relation) %}
+  {% else %}
+    {% set tmp_relation = make_temp_relation(target_relation) %}
+    {% if tmp_relation is not none %}
+      {% do adapter.drop_relation(tmp_relation) %}
+    {% endif %}
+    {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+    {% set build_sql = incremental_insert(on_schema_change, tmp_relation, target_relation, existing_relation) %}
+    {% do to_drop.append(tmp_relation) %}
   {% endif %}
 
   {% call statement("main") %}


### PR DESCRIPTION
I was testing dbt-athena@v1.3.2 today and I ran into an issue when my incremental table runs. 
This is a basic incremental materialization, with the default strategy `insert_overwrite` is used.

```
{{
    config(materialized='incremental', incremental_strategy='insert_overwrite')
}}
```

The first time (full refresh) it loads fine. After that, when incremental mode kicks in, I get an error:

```
21:17:53.743463 [debug] [Thread-1 (]: Opening a new connection, currently in state closed
Failed to execute query.
Traceback (most recent call last):
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/pyathena/common.py", line 494, in _execute
    query_id = retry_api_call(
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/pyathena/util.py", line 68, in retry_api_call
    return retry(func, *args, **kwargs)
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 406, in __call__
    do = self.iter(retry_state=retry_state)
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 351, in iter
    return fut.result()
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/tenacity/__init__.py", line 409, in __call__
    result = fn(*args, **kwargs)
  File "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/botocore/client.py", line 530, in _api_call
    return self._make_api_call(operation_name, kwargs)
  fFile "/Users/jesse.dobbelaere/XXX/.venv/lib/python3.10/site-packages/botocore/client.py", line 960, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidRequestException: An error occurred (InvalidRequestException) when calling the StartQueryExecution operation: line 1:157: mismatched input '<EOF>'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', 'INSERT', 'PREPARE', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UNLOAD', 'UPDATE', 'USE', <query>
```

The `mismatched input '<EOF>'` here means that an **empty query** is executed. 

I added some debugging and could trace this back to #47. It seems that the `{{ build_sql }}` is empty for my specific case. None of the if/else statements matches, so `build_sql` never gets set anywhere. There's an if block `{% elif partitioned_by is not none and strategy == 'insert_overwrite' %}` but my model does not use partitions, so it doesn't step into that. 

**I noticed in previous releases that we had an else block. I'm adding this back, and I confirm that it works again to run the incremental model 🎉** 

https://github.com/dbt-athena/dbt-athena/blob/v1.3.1/dbt/include/athena/macros/materializations/models/incremental/incremental.sql#L39-L47