### PR TITLE
feat: add on_schema_change for iceberg tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ The following features of dbt are not implemented on Athena:
 
 #### Known issues
 
+* Incremental Iceberg models - Sync all columns on schema change can't remove columns used as partitioning.
+The only way, from a dbt perspective, is to do a full-refresh of the incremental model.
+
 * Quoting is not currently supported
   * If you need to quote your sources, escape the quote characters in your source definitions:
 

--- a/dbt/include/athena/macros/materializations/models/incremental/column_helpers.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/column_helpers.sql
@@ -17,6 +17,19 @@
   {% endif %}
 {% endmacro %}
 
+{% macro alter_relation_drop_columns(relation, remove_columns = none) -%}
+  {% if remove_columns is none %}
+    {% set remove_columns = [] %}
+  {% endif %}
+
+  {%- for column in remove_columns -%}
+    {% set sql -%}
+      alter {{ relation.type }} {{ relation }} drop column {{ column.name }}
+    {% endset %}
+    {% do run_query(sql) %}
+  {%- endfor -%}
+{% endmacro %}
+
 {% macro alter_relation_replace_columns(relation, replace_columns = none) -%}
   {% if replace_columns is none %}
     {% set replace_columns = [] %}

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -84,7 +84,7 @@
       {% do adapter.drop_relation(tmp_relation) %}
     {% endif %}
     {% do run_query(create_tmp_table_iceberg(tmp_relation, sql, staging_location, false)) %}
-    {% set build_sql = iceberg_merge(tmp_relation, target_relation, unique_key) %}
+    {% set build_sql = iceberg_merge(on_schema_change, tmp_relation, target_relation, unique_key, existing_relation) %}
     {% do to_drop.append(tmp_relation) %}
   {% endif %}
 

--- a/dbt/include/athena/macros/materializations/models/incremental/merge.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/merge.sql
@@ -1,5 +1,8 @@
-{% macro iceberg_merge(tmp_relation, target_relation, unique_key, statement_name="main") %}
-    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+{% macro iceberg_merge(on_schema_change, tmp_relation, target_relation, unique_key, existing_relation, statement_name="main") %}
+    {% set dest_columns = process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
+    {% if not dest_columns %}
+      {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {% endif %}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
     {% if unique_key is sequence and unique_key is not string %}
       {%- set unique_key_cols = unique_key -%}


### PR DESCRIPTION
### Description
This PR introduces on_schema_change feature to the iceberg tables (append was already handled, we needed it for the merge strategy).
Fixes #51

## Model - test for adding and deleting columns
<!--- Add here the models that you use to test the changes -->

I used this model (I tested all the on_schema_change methods, I spent more time on the `sync_all_columns`):

```sql
{{ config(
  materialized='incremental',
  incremental_strategy='merge',
  unique_key='test_timestamp',
  partitioned_by=['hour(test_timestamp)'],
  on_schema_change='sync_all_columns',
  format='iceberg',
) }}


SELECT
    CAST(ts AS timestamp) AS test_timestamp
    , CAST(ts AS DATE) AS test_date
    , 'abc' AS test_string
    , 'cde' AS test_useless_string
    , true AS test_bool
    , 123 AS test_int
    , 123.45 AS test_float
    , CAST(1234.567 AS DECIMAL(7, 3)) AS test_decimal
    , CAST(34 AS BIGINT) AS test_bigint
    , CAST(123.33 AS DOUBLE) AS test_double
    , ARRAY['a'] AS test_array_string
    , ARRAY[1] AS test_array_int
    , ARRAY[false] AS test_array_bool
    , MAP(ARRAY['a'], ARRAY[1]) AS test_map_string_int
    , MAP(ARRAY['a'], ARRAY['b']) AS test_map_string_string
    , MAP(ARRAY['a'], ARRAY[true]) AS test_map_string_bool
    , MAP(ARRAY[1], ARRAY['a']) AS test_map_int_string
FROM {{ ref('iceberg_base_data_source') }}
{% if is_incremental() %}
  -- this filter will only be applied on an incremental run
  WHERE ts > (SELECT max(test_timestamp) FROM {{ this }})
{% endif %}
```

I tweaked then the model to that 

```sql
{{ config(
  materialized='incremental',
  incremental_strategy='merge',
  unique_key='test_timestamp',
  partitioned_by=['hour(test_timestamp)'],
  on_schema_change='sync_all_columns',
  format='iceberg',
) }}


SELECT
    CAST(ts AS timestamp) AS test_timestamp
    , CAST(ts AS DATE) AS test_date
    , 'abc' AS test_string
    , true AS test_bool
    , 123 AS test_int
    , 123.45 AS test_float
    , CAST(1234.567 AS DECIMAL(7, 3)) AS test_decimal
    , CAST(34 AS BIGINT) AS test_bigint
    , CAST(123.33 AS DOUBLE) AS test_double
    , ARRAY['a'] AS test_array_string
    , ARRAY[1] AS test_array_int
    , ARRAY[false] AS test_array_bool
    , MAP(ARRAY['a'], ARRAY[1]) AS test_map_string_int
    , MAP(ARRAY['a'], ARRAY['b']) AS test_map_string_string
    , MAP(ARRAY['a'], ARRAY[true]) AS test_map_string_bool
    , MAP(ARRAY[1], ARRAY['a']) AS test_map_int_string
    , MAP(ARRAY[1], ARRAY[1]) AS test_map_int_int
FROM {{ ref('iceberg_base_data_source') }}
{% if is_incremental() %}
  -- this filter will only be applied on an incremental run
  WHERE ts > (SELECT max(test_timestamp) FROM {{ this }})
{% endif %}
```

It did :
```sql
alter table test_dbt_athena.append_iceberg_table add columns (test_map_int_int map<int, int>)
```
```sql
alter table test_dbt_athena.append_iceberg_table drop column test_useless_string
```

## Model - test to delete column which has partitions

I used this model :

```sql
{{ config(
  materialized='incremental',
  incremental_strategy='merge',
  unique_key='test_timestamp',
  partitioned_by=['hour(test_timestamp)', 'bucket(16, test_category)'],
  on_schema_change='sync_all_columns',
  format='iceberg',
) }}


SELECT
    CAST(ts AS timestamp) AS test_timestamp
    , CAST(ts AS DATE) AS test_date
    , 'abc' AS test_string
    , true AS test_bool
    , 'cat' || cast(cast (random() * 100 as int) as varchar) as test_category
    , 123 AS test_int
    , 123.45 AS test_float
    , CAST(1234.567 AS DECIMAL(7, 3)) AS test_decimal
    , CAST(34 AS BIGINT) AS test_bigint
    , CAST(123.33 AS DOUBLE) AS test_double
    , ARRAY['a'] AS test_array_string
    , ARRAY[1] AS test_array_int
    , ARRAY[false] AS test_array_bool
    , MAP(ARRAY['a'], ARRAY[1]) AS test_map_string_int
    , MAP(ARRAY['a'], ARRAY['b']) AS test_map_string_string
    , MAP(ARRAY['a'], ARRAY[true]) AS test_map_string_bool
    , MAP(ARRAY[1], ARRAY['a']) AS test_map_int_string
    , MAP(ARRAY[1], ARRAY[1]) AS test_map_int_int
FROM {{ ref('iceberg_base_data_source') }}
{% if is_incremental() %}
  -- this filter will only be applied on an incremental run
  WHERE ts > (SELECT max(test_timestamp) FROM {{ this }})
{% endif %}
```

And then I tweaked it to remove the `test_category` from the sql and the `partitioned_by` config.

I got this error :
```
Input does not satisfy Iceberg requirements
```

Partition evolution is [not supported](https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg-additional-operations.html) yet. Therefore we must indicate in the README that partitioning columns can't be removed right now once they are in place.

## Checklist
- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You tested your changes
