### PR TITLE
Use presto escape rules for inserts

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -213,7 +213,12 @@ class AthenaParameterFormatter(Formatter):
             raise ProgrammingError("Query is none or empty.")
         operation = operation.strip()
 
-        if operation.upper().startswith(("SELECT", "WITH", "INSERT")):
+        operation_upper = operation.upper()
+        if (
+            operation_upper.startswith("SELECT")
+            or operation_upper.startswith("WITH")
+            or operation_upper.startswith("INSERT")
+        ):
             escaper = _escape_presto
         else:
             # Fixes ParseException that comes with newer version of PyAthena

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -117,3 +117,15 @@ class TestAthenaParameterFormatter:
             """
         ).strip()
         assert res == expected
+
+    def test_query_presto_style_escapes_for_inserts(self):
+        sql = self.formatter.format(
+            """
+            INSERT INTO table (str_field) VALUES (%s), (%s)
+        """,
+            [
+                "text",
+                "text with single quote'",
+            ],
+        )
+        assert sql == "INSERT INTO table (str_field) VALUES ('text'), ('text with single quote''')"


### PR DESCRIPTION
This fixes #60

### Description

`INSERT INTO ... VALUES` statements should use presto style escapes.


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You tested your changes
