### PR TITLE
feat: add support for external_location for seeds

### DIFF
--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -8,8 +8,8 @@
 {% endmacro %}
 
 {% macro athena__create_csv_table(model, agate_table) %}
-  {%- set column_override = model['config'].get('column_types', {}) -%}
-  {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
+  {%- set column_override = config.get('column_types', {}) -%}
+  {%- set quote_seed_column = config.get('quote_columns', None) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
   {%- set s3_data_naming = config.get('s3_data_naming', target.s3_data_naming) -%}
   {%- set external_location = config.get('external_location', default=none) -%}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -11,7 +11,7 @@
   {%- set column_override = model['config'].get('column_types', {}) -%}
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
-  {%- set s3_data_naming = model['config'].get('s3_data_naming', target.s3_data_naming) -%}
+  {%- set s3_data_naming = config.get('s3_data_naming', target.s3_data_naming) -%}
   {%- set external_location = config.get('external_location', default=none) -%}
 
   {% set sql %}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -12,6 +12,7 @@
   {%- set quote_seed_column = model['config'].get('quote_columns', None) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
   {%- set s3_data_naming = model['config'].get('s3_data_naming', target.s3_data_naming) -%}
+  {%- set external_location = config.get('external_location', default=none) -%}
 
   {% set sql %}
     create external table {{ this.render() }} (
@@ -23,7 +24,7 @@
         {%- endfor -%}
     )
     stored as parquet
-    location '{{ adapter.s3_table_location(s3_data_dir, s3_data_naming, model["schema"], model["alias"]) }}'
+    location '{{ adapter.s3_table_location(s3_data_dir, s3_data_naming, model["schema"], model["alias"], external_location) }}'
     tblproperties ('classification'='parquet')
   {% endset %}
 


### PR DESCRIPTION
### Description

Currently, we cannot set an `external_location` config for individual seed models. This PR is adding support to set an `external_location` when seeding seeds.

## Models used to test - Optional



## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
