### PR TITLE
fix: prune static s3 locations before CTA

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1,8 +1,8 @@
-import re
 from itertools import chain
 from os import path
 from threading import Lock
-from typing import Dict, Iterator, List, Optional, Set
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
+from urllib.parse import urlparse
 from uuid import uuid4
 
 import agate
@@ -100,7 +100,6 @@ class AthenaAdapter(SQLAdapter):
 
         with boto3_client_lock:
             glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
-        s3_resource = client.session.resource("s3", region_name=client.region_name, config=get_boto3_config())
         paginator = glue_client.get_paginator("get_partitions")
         partition_params = {
             "DatabaseName": database_name,
@@ -110,32 +109,12 @@ class AthenaAdapter(SQLAdapter):
         }
         partition_pg = paginator.paginate(**partition_params)
         partitions = partition_pg.build_full_result().get("Partitions")
-        s3_rg = re.compile("s3://([^/]*)/(.*)")
         for partition in partitions:
             logger.debug(
                 f"Deleting objects for partition '{partition['Values']}' "
                 f"at '{partition['StorageDescriptor']['Location']}'"
             )
-            m = s3_rg.match(partition["StorageDescriptor"]["Location"])
-            if m is not None:
-                bucket_name = m.group(1)
-                prefix = m.group(2)
-                s3_bucket = s3_resource.Bucket(bucket_name)
-                response = s3_bucket.objects.filter(Prefix=prefix).delete()
-                is_all_successful = True
-                for res in response:
-                    if "Errors" in res:
-                        for err in res["Errors"]:
-                            is_all_successful = False
-                            logger.error(
-                                "Failed to clean up partitions: Key='{}', Code='{}', Message='{}', s3_bucket='{}'",
-                                err["Key"],
-                                err["Code"],
-                                err["Message"],
-                                bucket_name,
-                            )
-                if is_all_successful is False:
-                    raise RuntimeException("Failed to clean up table partitions.")
+            self._delete_from_s3(client, partition["StorageDescriptor"]["Location"])
 
     @available
     def clean_up_table(self, database_name: str, table_name: str):
@@ -152,15 +131,9 @@ class AthenaAdapter(SQLAdapter):
                 return
 
         if table is not None:
-            p = re.compile("s3://([^/]*)/(.*)")
-            m = p.match(table["Table"]["StorageDescriptor"]["Location"])
-            if m is not None:
-                bucket_name = m.group(1)
-                prefix = m.group(2).rstrip("/") + "/"
-                logger.debug(f"Deleting table data from 's3://{bucket_name}/{prefix}'")
-                s3_resource = client.session.resource("s3", region_name=client.region_name, config=get_boto3_config())
-                s3_bucket = s3_resource.Bucket(bucket_name)
-                s3_bucket.objects.filter(Prefix=prefix).delete()
+            s3_location = table["Table"]["StorageDescriptor"]["Location"]
+            logger.debug(f"Deleting table data from '{s3_location}'")
+            self._delete_from_s3(client, s3_location)
 
     @available
     def prune_s3_table_location(self, s3_table_location: str):
@@ -172,19 +145,59 @@ class AthenaAdapter(SQLAdapter):
         """
         conn = self.connections.get_thread_connection()
         client = conn.handle
-        s3_resource = client.session.resource("s3", region_name=client.region_name)
-        p = re.compile("s3://([^/]*)/(.*)")
-        m = p.match(s3_table_location)
-        if m is not None:
-            bucket_name = m.group(1)
-            prefix = m.group(2)
-            s3_bucket = s3_resource.Bucket(bucket_name)
-            logger.debug(f"Pruning s3 table location: '{s3_table_location}'")
-            s3_bucket.objects.filter(Prefix=prefix).delete()
+        self._delete_from_s3(client, s3_table_location)
 
     @available
     def quote_seed_column(self, column: str, quote_config: Optional[bool]) -> str:
         return super().quote_seed_column(column, False)
+
+    def _delete_from_s3(self, client: Any, s3_path: str):
+        """
+        Deletes files from s3.
+        Additionally parses the response from the s3 delete request and raises
+        a RunTimeException in case it included errors.
+        """
+        bucket_name, prefix = self._parse_s3_path(s3_path)
+        if self._s3_path_exists(client, bucket_name, prefix):
+            s3_resource = client.session.resource("s3", region_name=client.region_name, config=get_boto3_config())
+            s3_bucket = s3_resource.Bucket(bucket_name)
+            response = s3_bucket.objects.filter(Prefix=prefix).delete()
+            is_all_successful = True
+            for res in response:
+                if "Errors" in res:
+                    for err in res["Errors"]:
+                        is_all_successful = False
+                        logger.error(
+                            "Failed to delete files: Key='{}', Code='{}', Message='{}', s3_bucket='{}'",
+                            err["Key"],
+                            err["Code"],
+                            err["Message"],
+                            bucket_name,
+                        )
+            if is_all_successful is False:
+                raise RuntimeException("Failed to delete files from S3.")
+        else:
+            logger.debug("S3 path does not exist")
+
+    @staticmethod
+    def _parse_s3_path(s3_path: str) -> Tuple[str, str]:
+        """
+        Parses and splits an s3 path into bucket name and prefix.
+        This assumes that s3_path is a prefix instead of a URI. It adds a
+        trailing slash to the prefix, if there is none.
+        """
+        o = urlparse(s3_path, allow_fragments=False)
+        bucket_name = o.netloc
+        prefix = o.path.lstrip("/").rstrip("/") + "/"
+        return bucket_name, prefix
+
+    @staticmethod
+    def _s3_path_exists(client: Any, s3_bucket: str, s3_prefix: str) -> bool:
+        """Checks whether a given s3 path exists."""
+        response = client.session.client(
+            "s3", region_name=client.region_name, config=get_boto3_config()
+        ).list_objects_v2(Bucket=s3_bucket, Prefix=s3_prefix)
+        return True if "Contents" in response else False
 
     def _join_catalog_table_owners(self, table: agate.Table, manifest: Manifest) -> agate.Table:
         owners = []

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -128,7 +128,6 @@ class AthenaAdapter(SQLAdapter):
 
         if table is not None:
             s3_location = table["Table"]["StorageDescriptor"]["Location"]
-            logger.debug(f"Deleting table data from '{s3_location}'")
             self._delete_from_s3(client, s3_location)
 
     @available

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -110,10 +110,6 @@ class AthenaAdapter(SQLAdapter):
         partition_pg = paginator.paginate(**partition_params)
         partitions = partition_pg.build_full_result().get("Partitions")
         for partition in partitions:
-            logger.debug(
-                f"Deleting objects for partition '{partition['Values']}' "
-                f"at '{partition['StorageDescriptor']['Location']}'"
-            )
             self._delete_from_s3(client, partition["StorageDescriptor"]["Location"])
 
     @available
@@ -161,6 +157,7 @@ class AthenaAdapter(SQLAdapter):
         if self._s3_path_exists(client, bucket_name, prefix):
             s3_resource = client.session.resource("s3", region_name=client.region_name, config=get_boto3_config())
             s3_bucket = s3_resource.Bucket(bucket_name)
+            logger.debug(f"Deleting table data: path='{s3_path}', bucket='{bucket_name}', prefix='{prefix}'")
             response = s3_bucket.objects.filter(Prefix=prefix).delete()
             is_all_successful = True
             for res in response:

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -34,16 +34,18 @@
       {%- endset -%}
       {% do exceptions.raise_compiler_error(error_unique_location_iceberg) %}
     {%- endif -%}
-  {%- elif external_location or s3_data_naming in ['table', 'schema_table'] -%}
-    {% do adapter.prune_s3_table_location(location) %}
   {%- endif %}
+
+{%- if table_type != 'iceberg' -%}
+    {% do adapter.prune_s3_table_location(location) %}
+{%- endif -%}
 
   create table
     {{ relation }}
   with (
     table_type='{{ table_type }}',
     is_external={%- if table_type == 'iceberg' -%}false{%- else -%}true{%- endif %},
-        {{ location_property }}='{{ location }}',
+    {{ location_property }}='{{ location }}',
   {%- if partitioned_by is not none %}
     {{ partition_property }}=ARRAY{{ partitioned_by | tojson | replace('\"', '\'') }},
   {%- endif %}

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -279,8 +279,10 @@ class TestAthenaAdapter:
         self.adapter.acquire_connection("dummy")
         self.adapter.clean_up_partitions(DATABASE_NAME, table_name, "dt < '2022-01-03'")
         assert (
-            "Deleting objects for partition '['2022-01-01']' at "
-            "'s3://test-dbt-athena-test-delete-partitions/tables/table/dt=2022-01-01'" in caplog.text
+            "Deleting table data: path="
+            "'s3://test-dbt-athena-test-delete-partitions/tables/table/dt=2022-01-01', "
+            "bucket='test-dbt-athena-test-delete-partitions', "
+            "prefix='tables/table/dt=2022-01-01/'" in caplog.text
         )
         assert (
             "Calling s3:delete_objects with {'Bucket': 'test-dbt-athena-test-delete-partitions', "
@@ -288,8 +290,10 @@ class TestAthenaAdapter:
             "{'Key': 'tables/table/dt=2022-01-01/data2.parquet'}]}}" in caplog.text
         )
         assert (
-            "Deleting objects for partition '['2022-01-02']' at "
-            "'s3://test-dbt-athena-test-delete-partitions/tables/table/dt=2022-01-02'" in caplog.text
+            "Deleting table data: path="
+            "'s3://test-dbt-athena-test-delete-partitions/tables/table/dt=2022-01-02', "
+            "bucket='test-dbt-athena-test-delete-partitions', "
+            "prefix='tables/table/dt=2022-01-02/'" in caplog.text
         )
         assert (
             "Calling s3:delete_objects with {'Bucket': 'test-dbt-athena-test-delete-partitions', "

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -541,3 +541,12 @@ class TestAthenaAdapterConversions(TestAdapterConversions):
         expected = ["date", "date", "date"]
         for col_idx, expect in enumerate(expected):
             assert AthenaAdapter.convert_date_type(agate_table, col_idx) == expect
+
+    def test_parse_s3_path(self):
+        s3_paths = [
+            "s3://my-bucket/test-dbt/tables/schema/table",
+            "s3://my-bucket/test-dbt/tables/schema/table/",
+        ]
+        expected = [("my-bucket", "test-dbt/tables/schema/table/"), ("my-bucket", "test-dbt/tables/schema/table/")]
+        for path, expect in zip(s3_paths, expected):
+            assert AthenaAdapter._parse_s3_path(path) == expect

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -463,18 +463,15 @@ class TestAthenaAdapter:
         self.adapter.list_relations_without_caching(schema_relation)
         parent_list_relations_without_caching.assert_called_once_with(schema_relation)
 
-    @pytest.fixture(scope="function")
-    def s3_paths(self):
-        return [
-            "s3://my-bucket/test-dbt/tables/schema/table",
-            "s3://my-bucket/test-dbt/tables/schema/table/",
-        ]
-
-    def test_parse_s3_path(self, s3_paths):
-        expected = [("my-bucket", "test-dbt/tables/schema/table/"), ("my-bucket", "test-dbt/tables/schema/table/")]
-
-        for path, expect in zip(s3_paths, expected):
-            assert AthenaAdapter._parse_s3_path(path) == expect
+    @pytest.mark.parametrize(
+        "s3_path,expected",
+        [
+            ("s3://my-bucket/test-dbt/tables/schema/table", ("my-bucket", "test-dbt/tables/schema/table/")),
+            ("s3://my-bucket/test-dbt/tables/schema/table/", ("my-bucket", "test-dbt/tables/schema/table/")),
+        ],
+    )
+    def test_parse_s3_path(self, s3_path, expected):
+        assert self.adapter._parse_s3_path(s3_path) == expected
 
 
 class TestAthenaFilterCatalog:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -463,6 +463,19 @@ class TestAthenaAdapter:
         self.adapter.list_relations_without_caching(schema_relation)
         parent_list_relations_without_caching.assert_called_once_with(schema_relation)
 
+    @pytest.fixture(scope="function")
+    def s3_paths(self):
+        return [
+            "s3://my-bucket/test-dbt/tables/schema/table",
+            "s3://my-bucket/test-dbt/tables/schema/table/",
+        ]
+
+    def test_parse_s3_path(self, s3_paths):
+        expected = [("my-bucket", "test-dbt/tables/schema/table/"), ("my-bucket", "test-dbt/tables/schema/table/")]
+
+        for path, expect in zip(s3_paths, expected):
+            assert AthenaAdapter._parse_s3_path(path) == expect
+
 
 class TestAthenaFilterCatalog:
     def test__catalog_filter_table(self):
@@ -541,12 +554,3 @@ class TestAthenaAdapterConversions(TestAdapterConversions):
         expected = ["date", "date", "date"]
         for col_idx, expect in enumerate(expected):
             assert AthenaAdapter.convert_date_type(agate_table, col_idx) == expect
-
-    def test_parse_s3_path(self):
-        s3_paths = [
-            "s3://my-bucket/test-dbt/tables/schema/table",
-            "s3://my-bucket/test-dbt/tables/schema/table/",
-        ]
-        expected = [("my-bucket", "test-dbt/tables/schema/table/"), ("my-bucket", "test-dbt/tables/schema/table/")]
-        for path, expect in zip(s3_paths, expected):
-            assert AthenaAdapter._parse_s3_path(path) == expect

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -320,7 +320,7 @@ class TestAthenaAdapter:
         self.mock_aws_service.add_data_in_table("table")
         self.adapter.acquire_connection("dummy")
         self.adapter.clean_up_table(DATABASE_NAME, "table")
-        assert "Deleting table data from 's3://test-dbt-athena-test-delete-partitions/tables/table/'" in caplog.text
+        assert "Deleting table data from 's3://test-dbt-athena-test-delete-partitions/tables/table'" in caplog.text
         s3 = boto3.client("s3", region_name=AWS_REGION)
         objs = s3.list_objects_v2(Bucket=BUCKET)
         assert objs["KeyCount"] == 0

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -324,7 +324,11 @@ class TestAthenaAdapter:
         self.mock_aws_service.add_data_in_table("table")
         self.adapter.acquire_connection("dummy")
         self.adapter.clean_up_table(DATABASE_NAME, "table")
-        assert "Deleting table data from 's3://test-dbt-athena-test-delete-partitions/tables/table'" in caplog.text
+        assert (
+            "Deleting table data: path='s3://test-dbt-athena-test-delete-partitions/tables/table', "
+            "bucket='test-dbt-athena-test-delete-partitions', "
+            "prefix='tables/table/'" in caplog.text
+        )
         s3 = boto3.client("s3", region_name=AWS_REGION)
         objs = s3.list_objects_v2(Bucket=BUCKET)
         assert objs["KeyCount"] == 0


### PR DESCRIPTION
### Description

I took a first stab at https://github.com/dbt-athena/dbt-athena/issues/58 as a follow-up on the discussion on [slack](https://getdbt.slack.com/archives/C013MLFR7BQ/p1669050058685359):

This is resolving the endless loop of `HIVE_PATH_ALREADY_EXISTS` errors, that occur whenever dbt receives a 503 Slow Down Error from s3, during a CTA statement after it has already written partial files to s3. For typical table materializations with static s3 locations, i.e. when using `external_location` or `s3_data_naming in ['table_table', 'schema_table']`, retrying keeps failing as the table was already dropped from Glue, while the partially written files never get deleted. This is 
- adding a new `prune_s3_table_location()` method to the AthenaAdapter
- adding a new method that handles s3 deletions, that also checks whether an s3_path exists
- proposing to use `urllib.parse` to split an s3_path, rather than using regex

I refactored the different methods to use this new s3 deletion method to make it more consistent. As a consequence, I had to remove one trailing `'/'` in one of the assertions as I'm passing the untreated s3 path to the debug log. So far, all existing tests succeeded, but it might be worth adding more tests.

Are there other materializations that should run the pruning step?

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
