### PR TITLE
feat!: dissociate table_format from table_type

### DIFF
--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -1,5 +1,5 @@
 {% macro drop_relation(relation) -%}
-  {% if config.get('format') != 'iceberg' and config.get('incremental_strategy') != 'append' %}
+  {% if config.get('table_type') != 'iceberg' and config.get('incremental_strategy') != 'append' %}
     {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
   {% endif %}
   {% call statement('drop_relation', auto_begin=False) -%}
@@ -8,7 +8,7 @@
 {% endmacro %}
 
 {% macro set_table_classification(relation) -%}
-  {%- set format = config.get('format') -%}
+  {%- set format = config.get('format', default='parquet') -%}
   {% call statement('set_table_classification', auto_begin=False) -%}
     alter table {{ relation }} set tblproperties ('classification' = '{{ format }}')
   {%- endcall %}

--- a/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
@@ -1,5 +1,5 @@
-{% macro validate_get_incremental_strategy(raw_strategy, format) %}
-  {%- if format == 'iceberg' -%}
+{% macro validate_get_incremental_strategy(raw_strategy, table_type) %}
+  {%- if table_type == 'iceberg' -%}
     {% set invalid_strategy_msg -%}
       Invalid incremental strategy provided: {{ raw_strategy }}
       Incremental models on Iceberg tables only work with 'append' or 'merge' (v3 only) strategy.

--- a/dbt/include/athena/macros/materializations/models/incremental/on_schema_change.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/on_schema_change.sql
@@ -1,6 +1,6 @@
 {% macro sync_column_schemas(on_schema_change, target_relation, schema_changes_dict) %}
   {%- set partitioned_by = config.get('partitioned_by', default=none) -%}
-  {% set format = config.get('format', default='parquet') %}
+  {% set table_type = config.get('table_type', default='hive') | lower %}
   {%- if partitioned_by is none -%}
       {%- set partitioned_by = [] -%}
   {%- endif %}
@@ -12,7 +12,7 @@
   {% elif on_schema_change == 'sync_all_columns' %}
      {%- set remove_from_target_arr = schema_changes_dict['target_not_in_source'] -%}
      {%- set new_target_types = schema_changes_dict['new_target_types'] -%}
-     {% if format == 'iceberg' %}
+     {% if table_type == 'iceberg' %}
        {% if add_to_target_arr | length > 0 %}
          {%- do alter_relation_add_columns(target_relation, add_to_target_arr) -%}
        {% endif %}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -4,6 +4,7 @@
   {%- set bucketed_by = config.get('bucketed_by', default=none) -%}
   {%- set bucket_count = config.get('bucket_count', default=none) -%}
   {%- set field_delimiter = config.get('field_delimiter', default=none) -%}
+  {%- set table_type = config.get('table_type', default='hive') | lower -%}
   {%- set format = config.get('format', default='parquet') -%}
   {%- set write_compression = config.get('write_compression', default=none) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
@@ -13,7 +14,7 @@
   {%- set location_property = 'external_location' -%}
   {%- set partition_property = 'partitioned_by' -%}
 
-  {%- if format == 'iceberg' -%}
+  {%- if table_type == 'iceberg' -%}
     {%- set location_property = 'location' -%}
     {%- set partition_property = 'partitioning' -%}
     {%- if bucketed_by is not none or bucket_count is not none -%}
@@ -37,8 +38,8 @@
   create table
     {{ relation }}
   with (
-    table_type={%- if format == 'iceberg' -%}'iceberg'{%- else -%}'hive'{%- endif %},
-    is_external={%- if format == 'iceberg' -%}false{%- else -%}true{%- endif %},
+    table_type='{{ table_type }}',
+    is_external={%- if table_type == 'iceberg' -%}false{%- else -%}true{%- endif %},
     {{ location_property }}='{{ adapter.s3_table_location(s3_data_dir, s3_data_naming, relation.schema, relation.identifier, external_location, temporary) }}',
   {%- if partitioned_by is not none %}
     {{ partition_property }}=ARRAY{{ partitioned_by | tojson | replace('\"', '\'') }},
@@ -55,7 +56,7 @@
   {%- if write_compression is not none %}
     write_compression='{{ write_compression }}',
   {%- endif %}
-    format={%- if format == 'iceberg' -%}'parquet'{%- else -%}'{{ format }}'{%- endif %}
+    format='{{ format }}'
   {%- if extra_table_properties is not none -%}
     {%- for prop_name, prop_value in extra_table_properties.items() -%}
     ,

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -1,7 +1,7 @@
 {% materialization table, adapter='athena' -%}
   {%- set identifier = model['alias'] -%}
 
-  {%- set format = config.get('format', default='parquet') -%}
+  {%- set table_type = config.get('table_type', default='hive') | lower -%}
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
@@ -20,7 +20,7 @@
     {{ create_table_as(False, target_relation, sql) }}
   {%- endcall %}
 
-  {% if format != 'iceberg' %}
+  {% if table_type != 'iceberg' %}
     {{ set_table_classification(target_relation) }}
   {% endif %}
 


### PR DESCRIPTION
### Description
Fixes #84

## Models used to test

**Iceberg with PARQUET**
```sql
{{ config(
  materialized='table',
  partitioned_by=['hour(ts)'],
  table_type='iceberg',
  table_properties={
    'vacuum_max_snapshot_age_seconds': '86400',
    'optimize_rewrite_delete_file_threshold': '2'
  }
) }}

SELECT cast(t.ts AS timestamp(6)) AS ts
FROM
    unnest(
        sequence(
            current_date - INTERVAL '1' DAY,
            cast(REPLACE(cast(current_timestamp as varchar), ' UTC', '') as timestamp(6)),
            INTERVAL '1' MINUTE
        )
    ) AS t(ts)
```
**Iceberg with AVRO**
```sql
{{ config(
  materialized='incremental',
  incremental_strategy='append',
  partitioned_by=['hour(ts)'],
  table_type='iceberg',
  format='avro',
) }}

SELECT
    ts
    , 'abc' AS str
FROM {{ ref('iceberg_data_source') }}
{% if is_incremental() %}
  -- this filter will only be applied on an incremental run
  WHERE ts > (SELECT max(ts) FROM {{ this }})
{% endif %}
```

**Iceberg with ORC**
```sql
{{ config(
  materialized='incremental',
  incremental_strategy='merge',
  partitioned_by=['hour(ts)'],
  unique_key='ts',
  table_type='iceberg',
  format='orc',
) }}

SELECT
    ts
    , 'abc' AS str
FROM {{ ref('iceberg_data_source') }}
{% if is_incremental() %}
  -- this filter will only be applied on an incremental run
  WHERE ts > (SELECT max(ts) FROM {{ this }})
{% endif %}
```

**Hive with JSON**
```sql
{{ config(
  materialized='table',
  format='json'
) }}

SELECT cast(t.ts AS timestamp(3)) AS ts
FROM
    unnest(
        sequence(
            current_date - INTERVAL '1' DAY,
            cast(REPLACE(cast(current_timestamp as varchar), ' UTC', '') as timestamp(3)),
            INTERVAL '1' MINUTE
        )
    ) AS t(ts)
```

**Hive with AVRO**
```sql
{{ config(
  materialized='incremental',
  incremental_strategy='append',
  format='avro'
) }}

SELECT
    ts
    , 'abc' AS str
FROM {{ ref('parquet_data_source') }}
{% if is_incremental() %}
  -- this filter will only be applied on an incremental run
  WHERE ts > (SELECT max(ts) FROM {{ this }})
{% endif %}
```

**Hive with PARQUET (Only works with v2 because of issue #89)**
```sql
{{ config(
  materialized='incremental',
  incremental_strategy='insert_overwrite',
  partitioned_by=['date_hour']
) }}

SELECT
    ts
    , 'abc' AS str
    , date_trunc('hour', ts) as date_hour
FROM {{ ref('parquet_data_source') }}
{% if is_incremental() %}
  -- this filter will only be applied on an incremental run
  WHERE ts > (SELECT max(date_hour) FROM {{ this }})
{% endif %}
```

## Checklist
- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [X] You added unit testing when necessary
- [X] You added functional testing when necessary
