### PR TITLE
fix: path should be dropped for append

### DIFF
--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -1,5 +1,5 @@
 {% macro drop_relation(relation) -%}
-  {% if config.get('table_type') != 'iceberg' and config.get('incremental_strategy') != 'append' %}
+  {% if config.get('table_type') != 'iceberg' %}
     {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
   {% endif %}
   {% call statement('drop_relation', auto_begin=False) -%}


### PR DESCRIPTION
### Description
This fix https://github.com/dbt-athena/dbt-athena/issues/98
When working with incremental and append model in parquet, my path was not pruned....looking at the code the drop is excluding append mode.
We should drop the s3 path as well when working with append mode as tables are accumulated, used for inserts and drop at the end.

## Models used to test - Optional
<pre>
{{ config(
    materialized='incremental',
    incremental_strategy='append',
    format='parquet',
    s3_data_naming='table'
) }}


select
    user_id,
    status,
    user_name
from {{ ref('parquet_example_1') }}

</pre>


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
