### PR TITLE
chore: add weekly dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Description

Add dependabot to automatically bump dependencies.

#### Note
If a specific library is broken, we can close the PR and dependabot won't open any pr for that specific version.


## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
