### PR TITLE
Fix database name when looking up tables

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -300,7 +300,7 @@ class AthenaAdapter(SQLAdapter):
 
                 relations.append(
                     self.Relation.create(
-                        schema=table["DatabaseName"],
+                        schema=schema_relation.schema,
                         database=schema_relation.database,
                         identifier=table["Name"],
                         quote_policy=quote_policy,


### PR DESCRIPTION
### Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->
🍿 I am switching to dbt-athena-community and noticed that all my models do not run a `drop table` anymore prior to deploying each model. However, I did not have this issue in other projects that are using dbt-athena-community 🤔 . 

Using Tomme's dbt-athena adapter it worked fine without issues. I noticed that after publishing to Pypi, Tomme merged one more PR which introduced botocore (glue api) instead of a pure SQL solution checking `INFORMATION_SCHEMA`. The `list_relations_without_caching` override got introduced: https://github.com/Tomme/dbt-athena/pull/105/files

In my edge case, we are using Lake Formation:
* A database `dev_embedded_reporting` is created in another AWS account and shared with my AWS account
* We create a Lake Formation ["resource link"](https://docs.aws.amazon.com/lake-formation/latest/dg/resource-links-about.html) called `embedded_reporting`. This makes the database appear in Athena under that name, and we can consume and produce data to that database. Notice that we dropped the prefix in the name. That's valid, you can give the resource link any name. As a consequence, we query the `embedded_reporting` database and in dbt we specify that name as well. 

Previously in the Tomme/dbt-athena adapter on Pypi, it would run a SQL query on INFORMATION_SCHEMA to get a list of tables and views. But since [PR 105](https://github.com/Tomme/dbt-athena/pull/105/files) we use the Glue api for this. **You can guess what happens next: Glue returns the original db name**. 

This is what essentially happens in the `list_relations_without_caching` function in dbt-athena with botocore:

![image](https://user-images.githubusercontent.com/1352979/212545176-7083c3ca-323a-4f86-8c2a-f95d619c5994.png)

We ask for tables in db name `embedded_reporting` but we take the db name from the API output, which is referring to the source database (and it's inaccessible using that name). 

**tl;dr Because of the db-name mismatch, dbt-athena thinks there's no table and does not execute a `drop table X` command.** 



## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
