### PR TITLE
fix: prevent errors in drop_table macro when table doesn'tt exist

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -345,4 +345,4 @@ class AthenaAdapter(SQLAdapter):
             return _type
 
         except glue_client.exceptions.EntityNotFoundException as e:
-            logger.debug(e)
+            logger.debug(f"Error calling Glue get_table: {e}")

--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -1,11 +1,13 @@
 {% macro athena__drop_relation(relation) -%}
   {% set rel_type = adapter.get_table_type(relation.schema, relation.table) %}
-  {%- if rel_type is not none and rel_type == 'table' %}
-    {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
-  {%- endif %}
+  {%- if rel_type is not none %}
+    {%- if rel_type == 'table' %}
+      {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
+    {%- endif %}
     {% call statement('drop_relation', auto_begin=False) -%}
-    drop {{ relation.type }} if exists {{ relation }}
-  {%- endcall %}
+      drop {{ relation.type }} if exists {{ relation }}
+    {%- endcall %}
+  {%- endif %}
 {% endmacro %}
 
 {% macro set_table_classification(relation) -%}


### PR DESCRIPTION
### Description

This PR fixes two issues with the updated `drop_table` macro in case the table doesn't exist:

- Logging the `EntityNotFoundException` directly leads to an error `Object of type EntityNotFoundException is not JSON serializable` when using JSON logging
- When the table is missing in Glue and `rel_type` is `None`, the drop table statement becomes `DROP None IF EXISTS <table>`

## Models used to test - Optional

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
