### PR TITLE
feat: add table_hive_ha materialization

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -415,11 +415,10 @@ class AthenaAdapter(SQLAdapter):
             }
         )
         table_versions = response_iterator.build_full_result().get("TableVersions")
-        logger.debug(f"Total versions {len(table_versions)}")
-        table_versions_ordered = sorted(table_versions, key=lambda i: i["Table"]["VersionId"], reverse=False)
+        logger.debug(f"Total table versions: {[v['VersionId'] for v in table_versions]}")
+        table_versions_ordered = sorted(table_versions, key=lambda i: int(i["Table"]["VersionId"]), reverse=True)
         versions_to_delete = table_versions_ordered[int(to_keep) :]
-
-        logger.debug(f"Preparing to delete {len(versions_to_delete)} versions from table {database_name}.{table_name}")
+        logger.debug(f"Versions to delete: {[v['VersionId'] for v in versions_to_delete]}")
 
         deleted_versions = []
         for v in versions_to_delete:

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -416,9 +416,8 @@ class AthenaAdapter(SQLAdapter):
         )
         table_versions = response_iterator.build_full_result().get("TableVersions")
         logger.debug(f"Total versions {len(table_versions)}")
-        table_versions_ordered = sorted(table_versions, key=lambda i: i["Table"]["UpdateTime"], reverse=True)
-
-        versions_to_delete = table_versions_ordered[int(to_keep) + 1 :]
+        table_versions_ordered = sorted(table_versions, key=lambda i: i["Table"]["VersionId"], reverse=False)
+        versions_to_delete = table_versions_ordered[int(to_keep) :]
 
         logger.debug(f"Preparing to delete {len(versions_to_delete)} versions from table {database_name}.{table_name}")
 

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -428,13 +428,13 @@ class AthenaAdapter(SQLAdapter):
                 glue_client.delete_table_version(
                     DatabaseName=database_name, TableName=table_name, VersionId=str(version)
                 )
+                deleted_versions.append(version)
                 logger.debug(f"Deleted version {version} of table {database_name}.{table_name} ")
                 if delete_s3:
                     self.delete_from_s3(location)
             except Exception as err:
-                logger.debug(f"There was this {err} when deleting location {location}")
+                logger.debug(f"There was an error when expiring table version {version} with error: {err}")
 
             logger.debug(f"{location} was deleted")
-            deleted_versions.append(version)
 
         return deleted_versions

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -376,13 +376,10 @@ class AthenaAdapter(SQLAdapter):
         src_table_partitions = glue_client.get_partitions(DatabaseName=src_database, TableName=src_table_name).get(
             "Partitions"
         )
-        logger.debug(src_table)
-        logger.debug(src_table_partitions)
 
         target_table_partitions = glue_client.get_partitions(
             DatabaseName=target_database, TableName=target_table_name
         ).get("Partitions")
-        logger.debug(target_table_partitions)
 
         target_table_version = {
             "Name": target_table_name,
@@ -393,8 +390,10 @@ class AthenaAdapter(SQLAdapter):
         }
 
         # perform a table swap
-        response = glue_client.update_table(DatabaseName=target_database, TableInput=target_table_version)
-        logger.debug(response)
+        glue_client.update_table(DatabaseName=target_database, TableInput=target_table_version)
+        logger.debug(
+            f"Table {target_database}.{target_table_name} swapped with the contend of {src_database}.{src_table}"
+        )
 
         # we delete the target table partitions in any case
         # if source table has partitions we need to delete and add partitions

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -1,4 +1,5 @@
 {% macro athena__create_table_as(temporary, relation, sql) -%}
+  {%- set materialized = config.get('materialized', default='table') -%}
   {%- set external_location = config.get('external_location', default=none) -%}
   {%- set partitioned_by = config.get('partitioned_by', default=none) -%}
   {%- set bucketed_by = config.get('bucketed_by', default=none) -%}
@@ -14,6 +15,10 @@
   {%- set location_property = 'external_location' -%}
   {%- set partition_property = 'partitioned_by' -%}
   {%- set location = adapter.s3_table_location(s3_data_dir, s3_data_naming, relation.schema, relation.identifier, external_location, temporary) -%}
+
+  {%- if materialized == 'table_hive_ha' -%}
+    {%- set location = location.replace('__ha', '') -%}
+  {%- endif %}
 
   {%- if table_type == 'iceberg' -%}
     {%- set location_property = 'location' -%}

--- a/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
@@ -1,6 +1,7 @@
 {% materialization table_hive_ha, adapter='athena' -%}
   {%- set identifier = model['alias'] -%}
   {%- set table_type = 'hive' -%}
+  {%- set versions_to_keep = config.get('versions_to_keep', default=3) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
   {%- set s3_data_naming = config.get('s3_data_naming', default='table_unique') -%}
   {%- set external_location = config.get('external_location', default=none) -%}
@@ -22,9 +23,12 @@
 
   -- cleanup
   {%- if old_relation is not none -%}
-    -- make tmp table unique, this give the guarantee that we always use a new path no matter what
-    {% set unique_identifier = adapter.get_unique_identifier() %}
-    {% set tmp_relation = make_temp_relation(target_relation, '_' + unique_identifier) %}
+    {% set tmp_relation = make_temp_relation(target_relation, '_ha') %}
+
+    -- be sure to drop the tmp_relation
+    {% call statement('drop_tmp_relation', auto_begin=False) -%}
+      drop table if exists {{ tmp_relation }}
+    {%- endcall %}
 
     -- create tmp table
     {% call statement('main') -%}
@@ -37,15 +41,13 @@
     -- swap table
     {% set swap_table = adapter.swap_table(tmp_relation.schema, tmp_relation.name, target_relation.schema, target_relation.table) %}
 
-    -- cleanup
-    {% set result_delete_location = adapter.prune_s3_table_location(original_table_location) %}
-
     -- delete glue tmp table, do not use drop_relation, as it will remove data of the target table
     {% call statement('drop_tmp_relation', auto_begin=False) -%}
       drop table if exists {{ tmp_relation }}
     {%- endcall %}
 
-    {% set result_table_version_expiration = adapter.expire_glue_table_versions(target_relation.schema, target_relation.table) %}
+    --{% set result_table_version_expiration = adapter.expire_glue_table_versions(target_relation.schema, target_relation.table, versions_to_keep, True) %}
+
 
   {%- else -%}
     {% call statement('main') -%}

--- a/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
@@ -46,7 +46,7 @@
       drop table if exists {{ tmp_relation }}
     {%- endcall %}
 
-    --{% set result_table_version_expiration = adapter.expire_glue_table_versions(target_relation.schema, target_relation.table, versions_to_keep, True) %}
+    {% set result_table_version_expiration = adapter.expire_glue_table_versions(target_relation.schema, target_relation.table, versions_to_keep, True) %}
 
 
   {%- else -%}

--- a/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
@@ -1,26 +1,31 @@
 {% materialization table_hive_ha, adapter='athena' -%}
   {%- set identifier = model['alias'] -%}
   {%- set table_type = 'hive' -%}
-
-  {%- set s3_data_naming = config.get('s3_data_naming', default='table') -%}
+  {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
+  {%- set s3_data_naming = config.get('s3_data_naming', default='table_unique') -%}
+  {%- set external_location = config.get('external_location', default=none) -%}
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
                                                 type='table') -%}
 
+  {%- if s3_data_naming in ['table', 'table_schema'] or external_location is not none -%}
+    {%- set error_unique_location_hive_ha -%}
+        You need to have an unique table location when using table_hive_ha materialization.
+        Use s3_data_naming table_unique or schema_table_unique, and avoid to set an explicit external_location.
+    {%- endset -%}
+    {% do exceptions.raise_compiler_error(error_unique_location_hive_ha) %}
+  {%- endif -%}
+
   {{ run_hooks(pre_hooks) }}
 
   -- cleanup
   {%- if old_relation is not none -%}
+    -- make tmp table unique, this give the guarantee that we always use a new path no matter what
     {% set unique_identifier = adapter.get_unique_identifier() %}
     {% set tmp_relation = make_temp_relation(target_relation, '_' + unique_identifier) %}
 
-    {%- if tmp_relation is not none -%}
-      {% call statement('drop_tmp_relation', auto_begin=False) -%}
-        drop table if exists {{ tmp_relation }}
-      {%- endcall %}
-    {% endif %}
     -- create tmp table
     {% call statement('main') -%}
       {{ create_table_as(False, tmp_relation, sql) }}
@@ -32,16 +37,15 @@
     -- swap table
     {% set swap_table = adapter.swap_table(tmp_relation.schema, tmp_relation.name, target_relation.schema, target_relation.table) %}
 
-    -- delete old table location
+    -- cleanup
     {% set result_delete_location = adapter.prune_s3_table_location(original_table_location) %}
 
-    -- TODO expire old table versions of target table -> this can be a macro
+    -- delete glue tmp table, do not use drop_relation, as it will remove data of the target table
+    {% call statement('drop_tmp_relation', auto_begin=False) -%}
+      drop table if exists {{ tmp_relation }}
+    {%- endcall %}
 
-    {%- if tmp_relation is not none -%}
-      {% call statement('drop_tmp_relation', auto_begin=False) -%}
-        drop table if exists {{ tmp_relation }}
-      {%- endcall %}
-    {% endif %}
+    {% set result_table_version_expiration = adapter.expire_glue_table_versions(target_relation.schema, target_relation.table) %}
 
   {%- else -%}
     {% call statement('main') -%}

--- a/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
@@ -23,7 +23,7 @@
 
   -- cleanup
   {%- if old_relation is not none -%}
-    {% set tmp_relation = make_temp_relation(target_relation, '_ha') %}
+    {% set tmp_relation = make_temp_relation(target_relation, '__ha') %}
 
     -- be sure to drop the tmp_relation
     {% call statement('drop_tmp_relation', auto_begin=False) -%}

--- a/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
@@ -1,7 +1,7 @@
 {% materialization table_hive_ha, adapter='athena' -%}
   {%- set identifier = model['alias'] -%}
   {%- set table_type = 'hive' -%}
-  {%- set versions_to_keep = config.get('versions_to_keep', default=3) -%}
+  {%- set versions_to_keep = config.get('versions_to_keep', default=4) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
   {%- set s3_data_naming = config.get('s3_data_naming', default='table_unique') -%}
   {%- set external_location = config.get('external_location', default=none) -%}

--- a/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
@@ -1,0 +1,60 @@
+{% materialization table_hive_ha, adapter='athena' -%}
+  {%- set identifier = model['alias'] -%}
+  {%- set table_type = 'hive' -%}
+
+  {%- set s3_data_naming = config.get('s3_data_naming', default='table') -%}
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier,
+                                                schema=schema,
+                                                database=database,
+                                                type='table') -%}
+
+  {{ run_hooks(pre_hooks) }}
+
+  -- cleanup
+  {%- if old_relation is not none -%}
+    {% set unique_identifier = adapter.get_unique_identifier() %}
+    {% set tmp_relation = make_temp_relation(target_relation, '_' + unique_identifier) %}
+
+    {%- if tmp_relation is not none -%}
+      {% call statement('drop_tmp_relation', auto_begin=False) -%}
+        drop table if exists {{ tmp_relation }}
+      {%- endcall %}
+    {% endif %}
+    -- create tmp table
+    {% call statement('main') -%}
+      {{ create_table_as(False, tmp_relation, sql) }}
+    {%- endcall %}
+
+    -- save the original target table location before swapping
+    {% set original_table_location = adapter.get_table_location(target_relation.schema, target_relation.table) %}
+
+    -- swap table
+    {% set swap_table = adapter.swap_table(tmp_relation.schema, tmp_relation.name, target_relation.schema, target_relation.table) %}
+
+    -- delete old table location
+    {% set result_delete_location = adapter.prune_s3_table_location(original_table_location) %}
+
+    -- TODO expire old table versions of target table -> this can be a macro
+
+    {%- if tmp_relation is not none -%}
+      {% call statement('drop_tmp_relation', auto_begin=False) -%}
+        drop table if exists {{ tmp_relation }}
+      {%- endcall %}
+    {% endif %}
+
+  {%- else -%}
+    {% call statement('main') -%}
+      {{ create_table_as(False, target_relation, sql) }}
+    {%- endcall %}
+  {% endif %}
+
+  {{ set_table_classification(target_relation) }}
+
+  {{ run_hooks(post_hooks) }}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ dbt-tests-adapter~=1.4.1
 flake8~=5.0
 Flake8-pyproject~=1.2
 isort~=5.11
-moto~=4.1
+moto==4.1.3.dev31
 pre-commit~=2.21
 pytest~=7.2
 pytest-cov~=4.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ dbt-tests-adapter~=1.4.1
 flake8~=5.0
 Flake8-pyproject~=1.2
 isort~=5.11
-moto==4.1.3.dev31
+moto~=4.1.3
 pre-commit~=2.21
 pytest~=7.2
 pytest-cov~=4.0

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -643,6 +643,7 @@ class TestAthenaAdapter:
         assert len(table_versions) == 4
         self.adapter.expire_glue_table_versions(DATABASE_NAME, table_name, 1, False)
         # TODO delete_table_version is not implemented in moto
+        # TODO moto issue https://github.com/getmoto/moto/issues/5952
         # assert len(deleted_versions) == 3
 
 

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -605,7 +605,7 @@ class TestAthenaAdapter:
     @mock_athena
     @mock_glue
     @mock_s3
-    def test_swap_table_with_no_partitions_to_one_without(self, aws_credentials):
+    def test_swap_table_with_no_partitions_to_one_with(self, aws_credentials):
         self.mock_aws_service.create_data_catalog()
         self.mock_aws_service.create_database()
         self.adapter.acquire_connection("dummy")

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -614,16 +614,18 @@ class TestAthenaAdapter:
         self.mock_aws_service.create_table(source_table)
         self.mock_aws_service.add_partitions_to_table(DATABASE_NAME, source_table)
         self.mock_aws_service.create_table_without_partitions(target_table)
-
-        self.adapter.swap_table(DATABASE_NAME, source_table, DATABASE_NAME, target_table)
         glue_client = boto3.client("glue", region_name=AWS_REGION)
-
         target_table_partitions = glue_client.get_partitions(DatabaseName=DATABASE_NAME, TableName=target_table).get(
             "Partitions"
         )
+        assert len(target_table_partitions) == 0
+        self.adapter.swap_table(DATABASE_NAME, source_table, DATABASE_NAME, target_table)
+        target_table_partitions_after = glue_client.get_partitions(
+            DatabaseName=DATABASE_NAME, TableName=target_table
+        ).get("Partitions")
 
         assert self.adapter.get_table_location(DATABASE_NAME, target_table) == f"s3://{BUCKET}/tables/{source_table}"
-        assert len(target_table_partitions) == 3
+        assert len(target_table_partitions_after) == 3
 
 
 class TestAthenaFilterCatalog:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -641,12 +641,9 @@ class TestAthenaAdapter:
         self.mock_aws_service.add_table_version(DATABASE_NAME, table_name)
         glue = boto3.client("glue", region_name=AWS_REGION)
         table_versions = glue.get_table_versions(DatabaseName=DATABASE_NAME, TableName=table_name).get("TableVersions")
-        print(table_versions)
         assert len(table_versions) == 4
-        # the expiration always leave the current version and the previous version
-        # if we have 4 versions and ask to expire 1, we will have only 2 version to delete
         deleted_versions = self.adapter.expire_glue_table_versions(DATABASE_NAME, table_name, 1, False)
-        assert len(deleted_versions) == 2
+        assert len(deleted_versions) == 3
 
 
 class TestAthenaFilterCatalog:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -629,7 +629,7 @@ class TestAthenaAdapter:
     @mock_athena
     @mock_glue
     @mock_s3
-    def test_expire_glue_table_versions(self, aws_credentials):
+    def test_expire_glue_table_versions(self, aws_credentials, dbt_debug_caplog):
         self.mock_aws_service.create_data_catalog()
         self.mock_aws_service.create_database()
         self.adapter.acquire_connection("dummy")
@@ -641,8 +641,9 @@ class TestAthenaAdapter:
         glue = boto3.client("glue", region_name=AWS_REGION)
         table_versions = glue.get_table_versions(DatabaseName=DATABASE_NAME, TableName=table_name).get("TableVersions")
         assert len(table_versions) == 4
-        deleted_versions = self.adapter.expire_glue_table_versions(DATABASE_NAME, table_name, 1, False)
-        assert len(deleted_versions) == 3
+        self.adapter.expire_glue_table_versions(DATABASE_NAME, table_name, 1, False)
+        # TODO delete_table_version is not implemented in moto
+        # assert len(deleted_versions) == 3
 
 
 class TestAthenaFilterCatalog:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -643,6 +643,7 @@ class TestAthenaAdapter:
         print(table_versions)
         assert len(table_versions) == 3
         # TODO due to a limitation with moto this is not fully testable
+        # TODO re-enable this test when the issue https://github.com/getmoto/moto/issues/5933 is fixed
         # self.adapter.expire_glue_table_versions(DATABASE_NAME, table_name, 1, False)
         # table_versions_after_expiration = glue.get_table_versions(
         #     DatabaseName=DATABASE_NAME,

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -546,6 +546,85 @@ class TestAthenaAdapter:
     def test_parse_s3_path(self, s3_path, expected):
         assert self.adapter._parse_s3_path(s3_path) == expected
 
+    @mock_athena
+    @mock_glue
+    @mock_s3
+    def test_swap_table_with_partitions(self, aws_credentials):
+        self.mock_aws_service.create_data_catalog()
+        self.mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        target_table = "target_table"
+        source_table = "source_table"
+        self.mock_aws_service.create_table(source_table)
+        self.mock_aws_service.add_partitions_to_table(DATABASE_NAME, source_table)
+        self.mock_aws_service.create_table(target_table)
+        self.mock_aws_service.add_partitions_to_table(DATABASE_NAME, source_table)
+        self.adapter.swap_table(DATABASE_NAME, source_table, DATABASE_NAME, target_table)
+        assert self.adapter.get_table_location(DATABASE_NAME, target_table) == f"s3://{BUCKET}/tables/{source_table}"
+
+    @mock_athena
+    @mock_glue
+    @mock_s3
+    def test_swap_table_without_partitions(self, aws_credentials):
+        self.mock_aws_service.create_data_catalog()
+        self.mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        target_table = "target_table"
+        source_table = "source_table"
+        self.mock_aws_service.create_table_without_partitions(source_table)
+        self.mock_aws_service.create_table_without_partitions(target_table)
+        self.adapter.swap_table(DATABASE_NAME, source_table, DATABASE_NAME, target_table)
+        assert self.adapter.get_table_location(DATABASE_NAME, target_table) == f"s3://{BUCKET}/tables/{source_table}"
+
+    @mock_athena
+    @mock_glue
+    @mock_s3
+    def test_swap_table_with_partitions_to_one_without(self, aws_credentials):
+        self.mock_aws_service.create_data_catalog()
+        self.mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        target_table = "target_table"
+        source_table = "source_table"
+        # source table does not have partitions
+        self.mock_aws_service.create_table_without_partitions(source_table)
+
+        # the target table has partitions
+        self.mock_aws_service.create_table(target_table)
+        self.mock_aws_service.add_partitions_to_table(DATABASE_NAME, target_table)
+
+        self.adapter.swap_table(DATABASE_NAME, source_table, DATABASE_NAME, target_table)
+        glue_client = boto3.client("glue", region_name=AWS_REGION)
+
+        target_table_partitions = glue_client.get_partitions(DatabaseName=DATABASE_NAME, TableName=target_table).get(
+            "Partitions"
+        )
+
+        assert self.adapter.get_table_location(DATABASE_NAME, target_table) == f"s3://{BUCKET}/tables/{source_table}"
+        assert len(target_table_partitions) == 0
+
+    @mock_athena
+    @mock_glue
+    @mock_s3
+    def test_swap_table_with_no_partitions_to_one_without(self, aws_credentials):
+        self.mock_aws_service.create_data_catalog()
+        self.mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        target_table = "target_table"
+        source_table = "source_table"
+        self.mock_aws_service.create_table(source_table)
+        self.mock_aws_service.add_partitions_to_table(DATABASE_NAME, source_table)
+        self.mock_aws_service.create_table_without_partitions(target_table)
+
+        self.adapter.swap_table(DATABASE_NAME, source_table, DATABASE_NAME, target_table)
+        glue_client = boto3.client("glue", region_name=AWS_REGION)
+
+        target_table_partitions = glue_client.get_partitions(DatabaseName=DATABASE_NAME, TableName=target_table).get(
+            "Partitions"
+        )
+
+        assert self.adapter.get_table_location(DATABASE_NAME, target_table) == f"s3://{BUCKET}/tables/{source_table}"
+        assert len(target_table_partitions) == 3
+
 
 class TestAthenaFilterCatalog:
     def test__catalog_filter_table(self):

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -638,17 +638,15 @@ class TestAthenaAdapter:
         self.mock_aws_service.create_table(table_name)
         self.mock_aws_service.add_table_version(DATABASE_NAME, table_name)
         self.mock_aws_service.add_table_version(DATABASE_NAME, table_name)
+        self.mock_aws_service.add_table_version(DATABASE_NAME, table_name)
         glue = boto3.client("glue", region_name=AWS_REGION)
         table_versions = glue.get_table_versions(DatabaseName=DATABASE_NAME, TableName=table_name).get("TableVersions")
         print(table_versions)
-        assert len(table_versions) == 3
-        # TODO due to a limitation with moto this is not fully testable
-        # TODO re-enable this test when the issue https://github.com/getmoto/moto/issues/5933 is fixed
-        # self.adapter.expire_glue_table_versions(DATABASE_NAME, table_name, 1, False)
-        # table_versions_after_expiration = glue.get_table_versions(
-        #     DatabaseName=DATABASE_NAME,
-        #     TableName=table_name).get("TableVersions")
-        # assert len(table_versions_after_expiration) == 1
+        assert len(table_versions) == 4
+        # the expiration always leave the current version and the previous version
+        # if we have 4 versions and ask to expire 1, we will have only 2 version to delete
+        deleted_versions = self.adapter.expire_glue_table_versions(DATABASE_NAME, table_name, 1, False)
+        assert len(deleted_versions) == 2
 
 
 class TestAthenaFilterCatalog:

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -197,6 +197,46 @@ class MockAWSService:
                     },
                 ],
                 "TableType": "table",
+                "Parameters": {
+                    "compressionType": "snappy",
+                    "classification": "parquet",
+                    "projection.enabled": "false",
+                    "typeOfData": "file",
+                },
+            },
+        )
+
+    def create_table_without_partitions(self, table_name: str):
+        glue = boto3.client("glue", region_name=AWS_REGION)
+        glue.create_table(
+            DatabaseName=DATABASE_NAME,
+            TableInput={
+                "Name": table_name,
+                "StorageDescriptor": {
+                    "Columns": [
+                        {
+                            "Name": "id",
+                            "Type": "string",
+                        },
+                        {
+                            "Name": "country",
+                            "Type": "string",
+                        },
+                        {
+                            "Name": "dt",
+                            "Type": "date",
+                        },
+                    ],
+                    "Location": f"s3://{BUCKET}/tables/{table_name}",
+                },
+                "PartitionKeys": [],
+                "TableType": "table",
+                "Parameters": {
+                    "compressionType": "snappy",
+                    "classification": "parquet",
+                    "projection.enabled": "false",
+                    "typeOfData": "file",
+                },
             },
         )
 
@@ -289,4 +329,34 @@ class MockAWSService:
         glue = boto3.client("glue", region_name=AWS_REGION)
         glue.batch_create_partition(
             DatabaseName="test_dbt_athena", TableName=table_name, PartitionInputList=partition_input_list
+        )
+
+    def add_partitions_to_table(self, database, table_name):
+        partition_input_list = [
+            {
+                "Values": [dt],
+                "StorageDescriptor": {
+                    "Columns": [
+                        {
+                            "Name": "id",
+                            "Type": "string",
+                        },
+                        {
+                            "Name": "country",
+                            "Type": "string",
+                        },
+                        {
+                            "Name": "dt",
+                            "Type": "date",
+                        },
+                    ],
+                    "Location": f"s3://{BUCKET}/tables/{table_name}/dt={dt}",
+                },
+                "Parameters": {"compressionType": "snappy", "classification": "parquet"},
+            }
+            for dt in ["2022-01-01", "2022-01-02", "2022-01-03"]
+        ]
+        glue = boto3.client("glue", region_name=AWS_REGION)
+        glue.batch_create_partition(
+            DatabaseName=database, TableName=table_name, PartitionInputList=partition_input_list
         )

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -360,3 +360,15 @@ class MockAWSService:
         glue.batch_create_partition(
             DatabaseName=database, TableName=table_name, PartitionInputList=partition_input_list
         )
+
+    def add_table_version(self, database, table_name):
+        glue = boto3.client("glue", region_name=AWS_REGION)
+        table = glue.get_table(DatabaseName=database, Name=table_name).get("Table")
+        new_table_version = {
+            "Name": table_name,
+            "StorageDescriptor": table["StorageDescriptor"],
+            "PartitionKeys": table["PartitionKeys"],
+            "TableType": table["TableType"],
+            "Parameters": table["Parameters"],
+        }
+        glue.update_table(DatabaseName=database, TableInput=new_table_version)


### PR DESCRIPTION
### Description

Add a new materialisation called `table_hive_ha` that extend the create_table_as, but with a not destructive behavior.

If the table is created for the first time it works like a normal table materialization.
If the table already exist, it create a tmp table (with the same attribute as the target relation), and then it uses a glue table swap that just point the target table to the new tmp table location.
If everything is successful the old table location is pruned, and the tmp table is dropped (note only catalog/glue definition).

To test that the materialization was working as expected I used this piece of code:
```
from pyathena import connect
import boto3
import os

os.environ['AWS_PROFILE'] = 'bi-staging'

session = boto3.session.Session(region_name='eu-central-1')

cursor = connect(
    work_group='data-engineering',
    session=session
).cursor()

while True:
    try:
        cursor.execute("select count(*) from silver_shared.ha_1")
        result = cursor.fetchall()
        print(result)
    except Exception as err:
        print(err)
```

## Remarks
*~ I add to refactor some boto3 calls on the way, as we were leaving so many clients open~ Refactor cover in another PR
* I notice a super little downtime when swapping from a table without partitions with a table with partitions, and reverse.

# TODO
- [x] Handle partitions and change of table with partitions
- [x] Add unit testing for swap_table
- [ ] Add unit testing for expire_glue_table_versions

## Models used to test - Optional
### With partitions
```
{{ config(
    materialized='table_hive_ha',
    format='parquet',
    s3_data_naming='table',
    partitioned_by=['status']
) }}

select
    'a' as user_id,
    'pi' as user_name,
    'active' as status
union all
select
    'b' as user_id,
    'sh' as user_name,
    'active' as status
union all
select
    'c' as user_id,
    'sh' as user_name,
    'disabled' as status
```

### Without partitions
```
{{ config(
    materialized='table_hive_ha',
    format='parquet',
    s3_data_naming='table'
) }}

select
    'a' as user_id,
    'pi' as user_name,
    'active' as status
union all
select
    'b' as user_id,
    'sh' as user_name,
    'active' as status
union all
select
    'c' as user_id,
    'sh' as user_name,
    'disabled' as status

```
## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
