### PR TITLE
fix: Utilize cache for snapshots

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -346,3 +346,17 @@ class AthenaAdapter(SQLAdapter):
 
         except glue_client.exceptions.EntityNotFoundException as e:
             logger.debug(f"Error calling Glue get_table: {e}")
+
+    def set_relations_cache(
+        self,
+        manifest: Manifest,
+        clear: bool = False,
+        required_schemas: Set[BaseRelation] = None,
+    ) -> None:
+        """Run a query that gets a populated cache of the relations in the
+        database and set the cache on this adapter.
+        """
+        with self.cache.lock:
+            if clear:
+                self.cache.clear()
+            self._relations_cache_for_schemas(manifest, required_schemas)

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -348,17 +348,3 @@ class AthenaAdapter(SQLAdapter):
 
         except glue_client.exceptions.EntityNotFoundException as e:
             logger.debug(f"Error calling Glue get_table: {e}")
-
-    def set_relations_cache(
-        self,
-        manifest: Manifest,
-        clear: bool = False,
-        required_schemas: Set[BaseRelation] = None,
-    ) -> None:
-        """Run a query that gets a populated cache of the relations in the
-        database and set the cache on this adapter.
-        """
-        with self.cache.lock:
-            if clear:
-                self.cache.clear()
-            self._relations_cache_for_schemas(manifest, required_schemas)


### PR DESCRIPTION
### Description

The snapshot logic does not utilize the cache that is built as database=None is different from database='awsdatacatalog'. 

This shows up with the following message in the log output

```
On "snapshot.dbt_dev.model_snapshot_1": cache miss for schema ".analytics_dev", this is inefficient
```

It also fixes a run time error that is due to dbt incorrectly labeling that the target snapshot doesn't exist even when the table is present

Athena allows database to be optional and treats all requests with a default awsdatacatalog database but in this repo database is not optional. So this MR handles this edge case.

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->
You can create the below files in your personal dbt project. Alternatively you can clone the [sample project](https://github.com/Avinash-1394/dbt-athena-development) I created. Afterwards you can do

```
poetry install
poetry run dbt build
```

### Seed

<details> employment_indicators_november_2022_csv_tables.csv

```
Series_reference,Period,Data_value,Suppressed
MEIM.S1WA,1999.04,80267,
MEIM.S1WA,1999.05,70803,
MEIM.S1WA,1999.06,65792,
MEIM.S1WA,1999.07,66194,
MEIM.S1WA,1999.08,67259,
MEIM.S1WA,1999.09,69691,
MEIM.S1WA,1999.1,72475,
MEIM.S1WA,1999.11,79263,
MEIM.S1WA,1999.12,86540,
MEIM.S1WA,2000.01,82552,
MEIM.S1WA,2000.02,81709,
MEIM.S1WA,2000.03,84126,
MEIM.S1WA,2000.04,77089,
MEIM.S1WA,2000.05,73811,
MEIM.S1WA,2000.06,70070,
MEIM.S1WA,2000.07,69873,
MEIM.S1WA,2000.08,71468,
MEIM.S1WA,2000.09,72462,
MEIM.S1WA,2000.1,74897,
```
</details>

### model.sql

```
{{ config(
    materialized="table"
) }}


SELECT 
    ROW_NUMBER() OVER () AS id
    , *
    , cast(from_unixtime(to_unixtime(now())) as timestamp(3)) AS refresh_timestamp
FROM {{ ref('employment_indicators_november_2022_csv_tables') }}
```

### snapshots

```
{% snapshot model_snapshot_1 %}

{{ 
    config
    (
        target_database='awsdatacatalog',
        target_schema='analytics_dev',
        unique_key='id',
        strategy='timestamp',
        updated_at='refresh_timestamp'
    ) 
}}
SELECT * from {{ ref('model') }}

{% endsnapshot %}
```

```
{% snapshot model_snapshot_2 %}

{{ 
    config
    (
        target_database='awsdatacatalog',
        target_schema='analytics_dev',
        unique_key='id',
        strategy='check',
        check_cols=['series_reference','data_value'],
    ) 
}}
SELECT * from {{ ref('model') }}

{% endsnapshot %}
```

```
{% snapshot model_snapshot_3 %}

{{ 
    config
    (
        target_database='awsdatacatalog',
        target_schema='analytics_dev',
        unique_key='id',
        strategy='timestamp',
        updated_at='refresh_timestamp',
        invalidate_hard_deletes=True,
    ) 
}}
SELECT * from {{ ref('model') }}

{% endsnapshot %}
```

## DBT Build Output

Command used 

```
dbt -d snapshot --threads 1
```

<details><summary>Before adding cache</summary>

```


============================== 2023-02-13 00:35:00.555257 | f26012b0-bca8-4178-a747-edc7755ae326 ==============================
[0m00:35:00.555257 [info ] [MainThread]: Running with dbt=1.4.1
[0m00:35:00.557698 [debug] [MainThread]: running dbt with arguments {'debug': True, 'write_json': True, 'use_colors': True, 'printer_width': 80, 'version_check': True, 'partial_parse': True, 'static_parser': True, 'profiles_dir': '/home/avinash1394/.dbt', 'send_anonymous_usage_stats': True, 'quiet': False, 'no_print': False, 'cache_selected_only': False, 'threads': 1, 'which': 'snapshot', 'rpc_method': 'snapshot', 'indirect_selection': 'eager'}
[0m00:35:00.558265 [debug] [MainThread]: Tracking: tracking
[0m00:35:00.560534 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'invocation', 'label': 'start', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f3e94130>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f1e421a0>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f1e423b0>]}
[0m00:35:00.599151 [debug] [MainThread]: Partial parsing enabled: 0 files deleted, 0 files added, 1 files changed.
[0m00:35:00.600086 [debug] [MainThread]: Partial parsing: updated file: dbt_athena://macros/materializations/snapshots/snapshot.sql
[0m00:35:00.714247 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'load_project', 'label': 'f26012b0-bca8-4178-a747-edc7755ae326', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f1c21de0>]}
[0m00:35:00.720664 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'resource_counts', 'label': 'f26012b0-bca8-4178-a747-edc7755ae326', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f1b96ce0>]}
[0m00:35:00.721274 [info ] [MainThread]: Found 1 model, 0 tests, 3 snapshots, 0 analyses, 304 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics
[0m00:35:00.721715 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'runnable_timing', 'label': 'f26012b0-bca8-4178-a747-edc7755ae326', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f3e94130>]}
[0m00:35:00.723387 [info ] [MainThread]: 
[0m00:35:00.725576 [debug] [MainThread]: Acquiring new athena connection 'master'
[0m00:35:00.727504 [debug] [ThreadPool]: Acquiring new athena connection 'list_awsdatacatalog'
[0m00:35:00.743033 [debug] [ThreadPool]: Using athena connection "list_awsdatacatalog"
[0m00:35:00.743722 [debug] [ThreadPool]: On list_awsdatacatalog: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "connection_name": "list_awsdatacatalog"} */

    select
        distinct schema_name

    from awsdatacatalog.INFORMATION_SCHEMA.schemata
  
[0m00:35:00.744244 [debug] [ThreadPool]: Opening a new connection, currently in state init
[0m00:35:02.713696 [debug] [ThreadPool]: SQL status: OK -1 in 2 seconds
[0m00:35:02.716873 [debug] [ThreadPool]: On list_awsdatacatalog: Close
[0m00:35:02.720301 [debug] [ThreadPool]: Acquiring new athena connection 'list_awsdatacatalog_analytics_dev'
[0m00:35:02.722092 [debug] [ThreadPool]: Opening a new connection, currently in state closed
[0m00:35:03.401473 [debug] [ThreadPool]: On list_awsdatacatalog_analytics_dev: Close
[0m00:35:03.406108 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'runnable_timing', 'label': 'f26012b0-bca8-4178-a747-edc7755ae326', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6ebf491e0>]}
[0m00:35:03.407688 [info ] [MainThread]: Concurrency: 1 threads (target='dev')
[0m00:35:03.408382 [info ] [MainThread]: 
[0m00:35:03.411871 [debug] [Thread-1 (]: Began running node snapshot.dbt_dev.model_snapshot_1
[0m00:35:03.412835 [info ] [Thread-1 (]: 1 of 3 START snapshot analytics_dev.model_snapshot_1 ........................... [RUN]
[0m00:35:03.414134 [debug] [Thread-1 (]: Acquiring new athena connection 'snapshot.dbt_dev.model_snapshot_1'
[0m00:35:03.415031 [debug] [Thread-1 (]: Began compiling node snapshot.dbt_dev.model_snapshot_1
[0m00:35:03.423216 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_1 (compile): 2023-02-13 00:35:03.415655 => 2023-02-13 00:35:03.423082
[0m00:35:03.424088 [debug] [Thread-1 (]: Began executing node snapshot.dbt_dev.model_snapshot_1
[0m00:35:03.460300 [debug] [Thread-1 (]: On "snapshot.dbt_dev.model_snapshot_1": cache miss for schema ".analytics_dev", this is inefficient
[0m00:35:03.461178 [debug] [Thread-1 (]: Opening a new connection, currently in state closed
[0m00:35:04.112453 [debug] [Thread-1 (]: with database=, schema=analytics_dev, relations=[ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='employment_indicators_november_2022_csv_tables'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_1'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_2'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_3')]
[0m00:35:04.129271 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:04.130005 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */

    select count(*)
        from "awsdatacatalog".INFORMATION_SCHEMA.SCHEMATA
        where catalog_name='awsdatacatalog'
          and schema_name='analytics_dev'
  
[0m00:35:05.969837 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:35:06.017195 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:06.018029 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_1')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:35:07.534151 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:35:07.964379 [debug] [Thread-1 (]: Athena adapter: Error calling Glue get_table: An error occurred (EntityNotFoundException) when calling the GetTable operation: Table model_snapshot_1__dbt_tmp not found.
[0m00:35:08.350734 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:35:08.351690 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:08.352368 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */

        
  
    

  

  create table
    analytics_dev.model_snapshot_1__dbt_tmp
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp/99762981-807c-4c49-8b34-09b54820900d',
    format='parquet'
  )
  as
    WITH snapshot_query AS (
        


SELECT * from analytics_dev.model

    )
    , snapshotted_data_base AS (
        SELECT *
          , ROW_NUMBER() OVER (
              PARTITION BY dbt_unique_key
              ORDER BY dbt_valid_from DESC
            ) AS dbt_snapshot_rn
        FROM analytics_dev.model_snapshot_1
    )
    , snapshotted_data AS (
        SELECT *
        FROM snapshotted_data_base
        WHERE dbt_snapshot_rn = 1
          AND dbt_change_type != 'delete'
    )
    , source_data AS (
        SELECT *
          , id AS dbt_unique_key
          , refresh_timestamp AS dbt_valid_from
          , to_hex(md5(to_utf8(coalesce(cast(id as varchar ), '')
         || '|' || coalesce(cast(refresh_timestamp as varchar ), '')
        ))) AS dbt_scd_id
        FROM snapshot_query
    )
    , upserts AS (
        SELECT source_data.*
          , CASE
              WHEN snapshotted_data.dbt_unique_key IS NULL THEN 'insert'
              ELSE 'update'
            END as dbt_change_type
          , CAST('9999-01-01' as timestamp) AS dbt_valid_to
          , True AS is_current_record
        FROM source_data
        LEFT JOIN snapshotted_data
               ON snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
        WHERE snapshotted_data.dbt_unique_key IS NULL
           OR (
                snapshotted_data.dbt_unique_key IS NOT NULL
            AND (
                (snapshotted_data.dbt_valid_from < source_data.refresh_timestamp)
            )
        )
    )
    SELECT * FROM upserts;
    

  
    
[0m00:35:10.877033 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:35:10.883087 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:10.883980 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_1__dbt_tmp')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:35:12.450240 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:35:12.457747 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:12.458649 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_1')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:35:13.961856 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:35:14.017063 [debug] [Thread-1 (]: On "snapshot.dbt_dev.model_snapshot_1": cache miss for schema ".analytics_dev", this is inefficient
[0m00:35:14.466727 [debug] [Thread-1 (]: with database=, schema=analytics_dev, relations=[ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='employment_indicators_november_2022_csv_tables'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_1'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_1__dbt_tmp'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_2'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_3')]
[0m00:35:14.472706 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:14.473413 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_1__dbt_tmp')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:35:15.972003 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:35:16.313552 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:35:16.314535 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:16.315194 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */

        
  
    

  

  create table
    analytics_dev.model_snapshot_1__dbt_tmp_1
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp_1/148f324e-0165-49b6-a462-fe582d3b1a87',
    format='parquet'
  )
  as
    SELECT
        
          id,
          series_reference,
          period,
          data_value,
          suppressed,
          refresh_timestamp,
          dbt_unique_key,
          dbt_valid_from,
          dbt_scd_id,
          dbt_change_type,
          dbt_valid_to,
          is_current_record
        ,dbt_snapshot_at
      from analytics_dev.model_snapshot_1
      WHERE dbt_unique_key NOT IN ( SELECT dbt_unique_key FROM analytics_dev.model_snapshot_1__dbt_tmp )
      UNION ALL
      SELECT
        
              
                id,
        
              
                series_reference,
        
              
                period,
        
              
                data_value,
        
              
                suppressed,
        
              
                refresh_timestamp,
        
              
                dbt_unique_key,
        
              
                dbt_valid_from,
        
              
                dbt_scd_id,
        
              
                dbt_change_type,
        
              
              CASE
              WHEN dbt_valid_to=CAST('9999-01-01' as timestamp) AND is_current_record=True
              THEN -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
              ELSE dbt_valid_to
              END AS dbt_valid_to,
        
              
              CASE WHEN is_current_record=True THEN False ELSE is_current_record END
              AS is_current_record
        
        ,-- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
      from analytics_dev.model_snapshot_1
      WHERE dbt_unique_key IN ( SELECT dbt_unique_key FROM analytics_dev.model_snapshot_1__dbt_tmp )
      UNION ALL
      SELECT
        
            id,
            series_reference,
            period,
            data_value,
            suppressed,
            refresh_timestamp,
            dbt_unique_key,
            dbt_valid_from,
            dbt_scd_id,
            dbt_change_type,
            dbt_valid_to,
            is_current_record
        ,-- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
      FROM analytics_dev.model_snapshot_1__dbt_tmp;

  
    
[0m00:35:18.896714 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:35:18.905326 [debug] [Thread-1 (]: On "snapshot.dbt_dev.model_snapshot_1": cache miss for schema ".analytics_dev", this is inefficient
[0m00:35:19.473446 [debug] [Thread-1 (]: with database=, schema=analytics_dev, relations=[ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='employment_indicators_november_2022_csv_tables'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_1'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_1__dbt_tmp'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_1__dbt_tmp_1'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_2'), ReferenceKeyMsg(database=None, schema='analytics_dev', identifier='model_snapshot_3')]
[0m00:35:19.905170 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_1
[0m00:35:19.906091 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:35:20.345962 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_1 is stored in s3://dbt-athena/analytics_dev/model_snapshot_1/75751c1a-c840-49d8-921b-822df8c7c649/
[0m00:35:20.728385 [debug] [Thread-1 (]: Athena adapter: Deleting table data: path='s3://dbt-athena/analytics_dev/model_snapshot_1/75751c1a-c840-49d8-921b-822df8c7c649/', bucket='dbt-athena', prefix='analytics_dev/model_snapshot_1/75751c1a-c840-49d8-921b-822df8c7c649/'
[0m00:35:21.172266 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:21.173067 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: drop table if exists analytics_dev.model_snapshot_1
[0m00:35:22.642662 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:35:22.958922 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:35:22.960141 [debug] [Thread-1 (]: Writing runtime sql for node "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:22.961196 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:22.961848 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */

      
  
    

  

  create table
    analytics_dev.model_snapshot_1
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_1/ea07a260-9416-479d-a385-94ff45156aab',
    format='parquet'
  )
  as
    SELECT * FROM analytics_dev.model_snapshot_1__dbt_tmp_1;

  

  
[0m00:35:25.504154 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:35:25.938169 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_1__dbt_tmp
[0m00:35:25.939020 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:35:26.363900 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_1__dbt_tmp is stored in s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp/99762981-807c-4c49-8b34-09b54820900d/
[0m00:35:26.705963 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:35:26.707128 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:26.707930 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: drop table if exists analytics_dev.model_snapshot_1__dbt_tmp
[0m00:35:28.191101 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:35:28.624692 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_1__dbt_tmp_1
[0m00:35:28.625538 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:35:29.067432 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_1__dbt_tmp_1 is stored in s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp_1/148f324e-0165-49b6-a462-fe582d3b1a87/
[0m00:35:29.417903 [debug] [Thread-1 (]: Athena adapter: Deleting table data: path='s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp_1/148f324e-0165-49b6-a462-fe582d3b1a87/', bucket='dbt-athena', prefix='analytics_dev/model_snapshot_1__dbt_tmp_1/148f324e-0165-49b6-a462-fe582d3b1a87/'
[0m00:35:29.838727 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:35:29.839520 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: drop table if exists analytics_dev.model_snapshot_1__dbt_tmp_1
[0m00:35:31.298743 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:35:31.302125 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_1 (execute): 2023-02-13 00:35:03.424708 => 2023-02-13 00:35:31.302021
[0m00:35:31.303046 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: Close
[0m00:35:31.304616 [debug] [Thread-1 (]: Sending event: {'category': 'dbt', 'action': 'run_model', 'label': 'f26012b0-bca8-4178-a747-edc7755ae326', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f1c51e70>]}
[0m00:35:31.305781 [info ] [Thread-1 (]: 1 of 3 OK snapshotted analytics_dev.model_snapshot_1 ........................... [[32msuccess[0m in 27.89s]
[0m00:35:31.309088 [debug] [Thread-1 (]: Finished running node snapshot.dbt_dev.model_snapshot_1
[0m00:35:31.310049 [debug] [Thread-1 (]: Began running node snapshot.dbt_dev.model_snapshot_2
[0m00:35:31.311163 [info ] [Thread-1 (]: 2 of 3 START snapshot analytics_dev.model_snapshot_2 ........................... [RUN]
[0m00:35:31.312498 [debug] [Thread-1 (]: Acquiring new athena connection 'snapshot.dbt_dev.model_snapshot_2'
[0m00:35:31.313924 [debug] [Thread-1 (]: Began compiling node snapshot.dbt_dev.model_snapshot_2
[0m00:35:31.323888 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_2 (compile): 2023-02-13 00:35:31.314627 => 2023-02-13 00:35:31.323749
[0m00:35:31.324800 [debug] [Thread-1 (]: Began executing node snapshot.dbt_dev.model_snapshot_2
[0m00:35:31.332259 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:35:31.332914 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */

    select count(*)
        from "awsdatacatalog".INFORMATION_SCHEMA.SCHEMATA
        where catalog_name='awsdatacatalog'
          and schema_name='analytics_dev'
  
[0m00:35:31.333495 [debug] [Thread-1 (]: Opening a new connection, currently in state closed
[0m00:35:33.202892 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:35:33.586751 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:35:33.587974 [debug] [Thread-1 (]: Writing runtime sql for node "snapshot.dbt_dev.model_snapshot_2"
[0m00:35:33.588992 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:35:33.589641 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */

      
  
    

  

  create table
    analytics_dev.model_snapshot_2
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_2/66b4779a-4e0e-49f6-a7cb-27fac550d853',
    format='parquet'
  )
  as
    
    SELECT *
      , id AS dbt_unique_key
      , 
    -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
 AS dbt_valid_from
      , to_hex(md5(to_utf8(coalesce(cast(id as varchar ), '')
         || '|' || coalesce(cast(
    -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
 as varchar ), '')
        ))) AS dbt_scd_id
      , 'insert' AS dbt_change_type
      , CAST('9999-01-01' as timestamp) AS dbt_valid_to
      , True AS is_current_record
      , -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
    FROM (


SELECT * from analytics_dev.model
) source;


  
  
[0m00:36:55.439238 [debug] [Thread-1 (]: Athena adapter: Error running SQL: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */

      
  
    

  

  create table
    analytics_dev.model_snapshot_2
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_2/66b4779a-4e0e-49f6-a7cb-27fac550d853',
    format='parquet'
  )
  as
    
    SELECT *
      , id AS dbt_unique_key
      , 
    -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
 AS dbt_valid_from
      , to_hex(md5(to_utf8(coalesce(cast(id as varchar ), '')
         || '|' || coalesce(cast(
    -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
 as varchar ), '')
        ))) AS dbt_scd_id
      , 'insert' AS dbt_change_type
      , CAST('9999-01-01' as timestamp) AS dbt_valid_to
      , True AS is_current_record
      , -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
    FROM (


SELECT * from analytics_dev.model
) source;


  
  
[0m00:36:55.440373 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_2 (execute): 2023-02-13 00:35:31.325411 => 2023-02-13 00:36:55.440251
[0m00:36:55.441083 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: Close
[0m00:36:55.444618 [debug] [Thread-1 (]: Runtime Error in snapshot model_snapshot_2 (snapshots/model_snapshot_2.sql)
  SYNTAX_ERROR: line 1:1: Destination table 'awsdatacatalog.analytics_dev.model_snapshot_2' already exists. You may need to manually clean the data at location 's3://avinash1394-athena-query-results/tables/b335caaa-6a9a-4241-aac1-de1645c311f9' before retrying. Athena will not delete data in your account.
[0m00:36:55.445513 [debug] [Thread-1 (]: Sending event: {'category': 'dbt', 'action': 'run_model', 'label': 'f26012b0-bca8-4178-a747-edc7755ae326', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f127a7d0>]}
[0m00:36:55.446599 [error] [Thread-1 (]: 2 of 3 ERROR snapshotting analytics_dev.model_snapshot_2 ....................... [[31mERROR[0m in 84.13s]
[0m00:36:55.447386 [debug] [Thread-1 (]: Finished running node snapshot.dbt_dev.model_snapshot_2
[0m00:36:55.448223 [debug] [Thread-1 (]: Began running node snapshot.dbt_dev.model_snapshot_3
[0m00:36:55.449305 [info ] [Thread-1 (]: 3 of 3 START snapshot analytics_dev.model_snapshot_3 ........................... [RUN]
[0m00:36:55.450598 [debug] [Thread-1 (]: Acquiring new athena connection 'snapshot.dbt_dev.model_snapshot_3'
[0m00:36:55.451354 [debug] [Thread-1 (]: Began compiling node snapshot.dbt_dev.model_snapshot_3
[0m00:36:55.457903 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_3 (compile): 2023-02-13 00:36:55.451937 => 2023-02-13 00:36:55.457792
[0m00:36:55.458630 [debug] [Thread-1 (]: Began executing node snapshot.dbt_dev.model_snapshot_3
[0m00:36:55.465415 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:36:55.466051 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */

    select count(*)
        from "awsdatacatalog".INFORMATION_SCHEMA.SCHEMATA
        where catalog_name='awsdatacatalog'
          and schema_name='analytics_dev'
  
[0m00:36:55.466623 [debug] [Thread-1 (]: Opening a new connection, currently in state closed
[0m00:36:57.280286 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:36:57.608848 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:36:57.610068 [debug] [Thread-1 (]: Writing runtime sql for node "snapshot.dbt_dev.model_snapshot_3"
[0m00:36:57.611106 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:36:57.611762 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */

      
  
    

  

  create table
    analytics_dev.model_snapshot_3
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_3/197e8823-1521-4158-b45f-53fa201dd92c',
    format='parquet'
  )
  as
    
    SELECT *
      , id AS dbt_unique_key
      , refresh_timestamp AS dbt_valid_from
      , to_hex(md5(to_utf8(coalesce(cast(id as varchar ), '')
         || '|' || coalesce(cast(refresh_timestamp as varchar ), '')
        ))) AS dbt_scd_id
      , 'insert' AS dbt_change_type
      , CAST('9999-01-01' as timestamp) AS dbt_valid_to
      , True AS is_current_record
      , -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
    FROM (


SELECT * from analytics_dev.model
) source;


  
  
[0m00:38:19.261521 [debug] [Thread-1 (]: Athena adapter: Error running SQL: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */

      
  
    

  

  create table
    analytics_dev.model_snapshot_3
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_3/197e8823-1521-4158-b45f-53fa201dd92c',
    format='parquet'
  )
  as
    
    SELECT *
      , id AS dbt_unique_key
      , refresh_timestamp AS dbt_valid_from
      , to_hex(md5(to_utf8(coalesce(cast(id as varchar ), '')
         || '|' || coalesce(cast(refresh_timestamp as varchar ), '')
        ))) AS dbt_scd_id
      , 'insert' AS dbt_change_type
      , CAST('9999-01-01' as timestamp) AS dbt_valid_to
      , True AS is_current_record
      , -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
    FROM (


SELECT * from analytics_dev.model
) source;


  
  
[0m00:38:19.262476 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_3 (execute): 2023-02-13 00:36:55.459186 => 2023-02-13 00:38:19.262355
[0m00:38:19.263047 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: Close
[0m00:38:19.265123 [debug] [Thread-1 (]: Runtime Error in snapshot model_snapshot_3 (snapshots/model_snapshot_3.sql)
  SYNTAX_ERROR: line 1:1: Destination table 'awsdatacatalog.analytics_dev.model_snapshot_3' already exists. You may need to manually clean the data at location 's3://avinash1394-athena-query-results/tables/0ac84f67-7a76-4311-b8e5-e1fe7473dff6' before retrying. Athena will not delete data in your account.
[0m00:38:19.266037 [debug] [Thread-1 (]: Sending event: {'category': 'dbt', 'action': 'run_model', 'label': 'f26012b0-bca8-4178-a747-edc7755ae326', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6ebf0b1f0>]}
[0m00:38:19.267206 [error] [Thread-1 (]: 3 of 3 ERROR snapshotting analytics_dev.model_snapshot_3 ....................... [[31mERROR[0m in 83.82s]
[0m00:38:19.268362 [debug] [Thread-1 (]: Finished running node snapshot.dbt_dev.model_snapshot_3
[0m00:38:19.271564 [debug] [MainThread]: Acquiring new athena connection 'master'
[0m00:38:19.272831 [debug] [MainThread]: Connection 'master' was properly closed.
[0m00:38:19.273491 [debug] [MainThread]: Connection 'snapshot.dbt_dev.model_snapshot_3' was properly closed.
[0m00:38:19.274173 [info ] [MainThread]: 
[0m00:38:19.274679 [info ] [MainThread]: Finished running 3 snapshots in 0 hours 3 minutes and 18.55 seconds (198.55s).
[0m00:38:19.275213 [debug] [MainThread]: Command end result
[0m00:38:19.282651 [info ] [MainThread]: 
[0m00:38:19.283505 [info ] [MainThread]: [31mCompleted with 2 errors and 0 warnings:[0m
[0m00:38:19.284210 [info ] [MainThread]: 
[0m00:38:19.284843 [error] [MainThread]: [33mRuntime Error in snapshot model_snapshot_2 (snapshots/model_snapshot_2.sql)[0m
[0m00:38:19.285471 [error] [MainThread]:   SYNTAX_ERROR: line 1:1: Destination table 'awsdatacatalog.analytics_dev.model_snapshot_2' already exists. You may need to manually clean the data at location 's3://avinash1394-athena-query-results/tables/b335caaa-6a9a-4241-aac1-de1645c311f9' before retrying. Athena will not delete data in your account.
[0m00:38:19.286353 [info ] [MainThread]: 
[0m00:38:19.287159 [error] [MainThread]: [33mRuntime Error in snapshot model_snapshot_3 (snapshots/model_snapshot_3.sql)[0m
[0m00:38:19.287832 [error] [MainThread]:   SYNTAX_ERROR: line 1:1: Destination table 'awsdatacatalog.analytics_dev.model_snapshot_3' already exists. You may need to manually clean the data at location 's3://avinash1394-athena-query-results/tables/0ac84f67-7a76-4311-b8e5-e1fe7473dff6' before retrying. Athena will not delete data in your account.
[0m00:38:19.288402 [info ] [MainThread]: 
[0m00:38:19.288834 [info ] [MainThread]: Done. PASS=1 WARN=0 ERROR=2 SKIP=0 TOTAL=3
[0m00:38:19.289408 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'invocation', 'label': 'end', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6ea52a440>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f2325690>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7ff6f1c669b0>]}
[0m00:38:19.290056 [debug] [MainThread]: Flushing usage events

```

</details>

<details><summary>After adding cache support</summary

```


============================== 2023-02-13 00:19:14.368453 | 4ca07f92-0d0b-4769-bafe-23a2535eb485 ==============================
[0m00:19:14.368453 [info ] [MainThread]: Running with dbt=1.4.1
[0m00:19:14.370498 [debug] [MainThread]: running dbt with arguments {'debug': True, 'write_json': True, 'use_colors': True, 'printer_width': 80, 'version_check': True, 'partial_parse': True, 'static_parser': True, 'profiles_dir': '/home/avinash1394/.dbt', 'send_anonymous_usage_stats': True, 'quiet': False, 'no_print': False, 'cache_selected_only': False, 'threads': 1, 'which': 'snapshot', 'rpc_method': 'snapshot', 'indirect_selection': 'eager'}
[0m00:19:14.370948 [debug] [MainThread]: Tracking: tracking
[0m00:19:14.372788 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'invocation', 'label': 'start', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f9ba2de40>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f99a36170>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f99a36380>]}
[0m00:19:14.410001 [debug] [MainThread]: Partial parsing enabled: 0 files deleted, 0 files added, 1 files changed.
[0m00:19:14.411254 [debug] [MainThread]: Partial parsing: updated file: dbt_athena://macros/adapters/relation.sql
[0m00:19:14.584157 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'load_project', 'label': '4ca07f92-0d0b-4769-bafe-23a2535eb485', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f99805000>]}
[0m00:19:14.590281 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'resource_counts', 'label': '4ca07f92-0d0b-4769-bafe-23a2535eb485', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f99789f00>]}
[0m00:19:14.590817 [info ] [MainThread]: Found 1 model, 0 tests, 3 snapshots, 0 analyses, 304 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics
[0m00:19:14.591208 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'runnable_timing', 'label': '4ca07f92-0d0b-4769-bafe-23a2535eb485', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f9ba2de40>]}
[0m00:19:14.592735 [info ] [MainThread]: 
[0m00:19:14.594598 [debug] [MainThread]: Acquiring new athena connection 'master'
[0m00:19:14.596462 [debug] [ThreadPool]: Acquiring new athena connection 'list_awsdatacatalog'
[0m00:19:14.610063 [debug] [ThreadPool]: Using athena connection "list_awsdatacatalog"
[0m00:19:14.610419 [debug] [ThreadPool]: On list_awsdatacatalog: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "connection_name": "list_awsdatacatalog"} */

    select
        distinct schema_name

    from awsdatacatalog.INFORMATION_SCHEMA.schemata
  
[0m00:19:14.610768 [debug] [ThreadPool]: Opening a new connection, currently in state init
[0m00:19:16.606656 [debug] [ThreadPool]: SQL status: OK -1 in 2 seconds
[0m00:19:16.610087 [debug] [ThreadPool]: On list_awsdatacatalog: Close
[0m00:19:16.613840 [debug] [ThreadPool]: Acquiring new athena connection 'list_awsdatacatalog_analytics_dev'
[0m00:19:16.615741 [debug] [ThreadPool]: Opening a new connection, currently in state closed
[0m00:19:17.159903 [debug] [ThreadPool]: On list_awsdatacatalog_analytics_dev: Close
[0m00:19:17.164535 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'runnable_timing', 'label': '4ca07f92-0d0b-4769-bafe-23a2535eb485', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f93b910f0>]}
[0m00:19:17.166134 [info ] [MainThread]: Concurrency: 1 threads (target='dev')
[0m00:19:17.166836 [info ] [MainThread]: 
[0m00:19:17.172090 [debug] [Thread-1 (]: Began running node snapshot.dbt_dev.model_snapshot_1
[0m00:19:17.173098 [info ] [Thread-1 (]: 1 of 3 START snapshot analytics_dev.model_snapshot_1 ........................... [RUN]
[0m00:19:17.174462 [debug] [Thread-1 (]: Acquiring new athena connection 'snapshot.dbt_dev.model_snapshot_1'
[0m00:19:17.175394 [debug] [Thread-1 (]: Began compiling node snapshot.dbt_dev.model_snapshot_1
[0m00:19:17.181956 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_1 (compile): 2023-02-13 00:19:17.176023 => 2023-02-13 00:19:17.181827
[0m00:19:17.182822 [debug] [Thread-1 (]: Began executing node snapshot.dbt_dev.model_snapshot_1
[0m00:19:17.209297 [debug] [Thread-1 (]: Checking if target table exists
[0m00:19:17.234731 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:17.235435 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */

    select count(*)
        from "awsdatacatalog".INFORMATION_SCHEMA.SCHEMATA
        where catalog_name='awsdatacatalog'
          and schema_name='analytics_dev'
  
[0m00:19:17.236060 [debug] [Thread-1 (]: Opening a new connection, currently in state closed
[0m00:19:19.026620 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:19.073941 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:19.074714 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_1')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:20.616340 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:21.075974 [debug] [Thread-1 (]: Athena adapter: Error calling Glue get_table: An error occurred (EntityNotFoundException) when calling the GetTable operation: Table model_snapshot_1__dbt_tmp not found.
[0m00:19:21.454192 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:19:21.455167 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:21.455841 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */

        
  
    

  

  create table
    analytics_dev.model_snapshot_1__dbt_tmp
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp/ef6e1a53-2c6b-443e-a352-ae72d15cf268',
    format='parquet'
  )
  as
    WITH snapshot_query AS (
        


SELECT * from analytics_dev.model

    )
    , snapshotted_data_base AS (
        SELECT *
          , ROW_NUMBER() OVER (
              PARTITION BY dbt_unique_key
              ORDER BY dbt_valid_from DESC
            ) AS dbt_snapshot_rn
        FROM analytics_dev.model_snapshot_1
    )
    , snapshotted_data AS (
        SELECT *
        FROM snapshotted_data_base
        WHERE dbt_snapshot_rn = 1
          AND dbt_change_type != 'delete'
    )
    , source_data AS (
        SELECT *
          , id AS dbt_unique_key
          , refresh_timestamp AS dbt_valid_from
          , to_hex(md5(to_utf8(coalesce(cast(id as varchar ), '')
         || '|' || coalesce(cast(refresh_timestamp as varchar ), '')
        ))) AS dbt_scd_id
        FROM snapshot_query
    )
    , upserts AS (
        SELECT source_data.*
          , CASE
              WHEN snapshotted_data.dbt_unique_key IS NULL THEN 'insert'
              ELSE 'update'
            END as dbt_change_type
          , CAST('9999-01-01' as timestamp) AS dbt_valid_to
          , True AS is_current_record
        FROM source_data
        LEFT JOIN snapshotted_data
               ON snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
        WHERE snapshotted_data.dbt_unique_key IS NULL
           OR (
                snapshotted_data.dbt_unique_key IS NOT NULL
            AND (
                (snapshotted_data.dbt_valid_from < source_data.refresh_timestamp)
            )
        )
    )
    SELECT * FROM upserts;
    

  
    
[0m00:19:24.042672 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:19:24.140308 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:24.140739 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_1__dbt_tmp')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:26.734738 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:19:26.742317 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:26.743220 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_1')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:28.252456 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:28.291687 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:28.292416 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_1__dbt_tmp')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:29.845315 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:30.190943 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:19:30.191918 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:30.192579 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */

        
  
    

  

  create table
    analytics_dev.model_snapshot_1__dbt_tmp_1
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp_1/d0c499cf-dd36-417b-ba66-9ee9616dbb7d',
    format='parquet'
  )
  as
    SELECT
        
          id,
          series_reference,
          period,
          data_value,
          suppressed,
          refresh_timestamp,
          dbt_unique_key,
          dbt_valid_from,
          dbt_scd_id,
          dbt_change_type,
          dbt_valid_to,
          is_current_record
        ,dbt_snapshot_at
      from analytics_dev.model_snapshot_1
      WHERE dbt_unique_key NOT IN ( SELECT dbt_unique_key FROM analytics_dev.model_snapshot_1__dbt_tmp )
      UNION ALL
      SELECT
        
              
                id,
        
              
                series_reference,
        
              
                period,
        
              
                data_value,
        
              
                suppressed,
        
              
                refresh_timestamp,
        
              
                dbt_unique_key,
        
              
                dbt_valid_from,
        
              
                dbt_scd_id,
        
              
                dbt_change_type,
        
              
              CASE
              WHEN dbt_valid_to=CAST('9999-01-01' as timestamp) AND is_current_record=True
              THEN -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
              ELSE dbt_valid_to
              END AS dbt_valid_to,
        
              
              CASE WHEN is_current_record=True THEN False ELSE is_current_record END
              AS is_current_record
        
        ,-- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
      from analytics_dev.model_snapshot_1
      WHERE dbt_unique_key IN ( SELECT dbt_unique_key FROM analytics_dev.model_snapshot_1__dbt_tmp )
      UNION ALL
      SELECT
        
            id,
            series_reference,
            period,
            data_value,
            suppressed,
            refresh_timestamp,
            dbt_unique_key,
            dbt_valid_from,
            dbt_scd_id,
            dbt_change_type,
            dbt_valid_to,
            is_current_record
        ,-- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
      FROM analytics_dev.model_snapshot_1__dbt_tmp;

  
    
[0m00:19:32.763435 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:19:33.280141 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_1
[0m00:19:33.281046 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:19:33.791453 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_1 is stored in s3://dbt-athena/analytics_dev/model_snapshot_1/ae97cb8e-90b9-4076-8817-fbda467e3651/
[0m00:19:34.152656 [debug] [Thread-1 (]: Athena adapter: Deleting table data: path='s3://dbt-athena/analytics_dev/model_snapshot_1/ae97cb8e-90b9-4076-8817-fbda467e3651/', bucket='dbt-athena', prefix='analytics_dev/model_snapshot_1/ae97cb8e-90b9-4076-8817-fbda467e3651/'
[0m00:19:34.592654 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:34.593465 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: drop table if exists analytics_dev.model_snapshot_1
[0m00:19:36.029770 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:19:36.437857 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:19:36.456541 [debug] [Thread-1 (]: Writing runtime sql for node "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:36.457766 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:36.458430 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_1"} */

      
  
    

  

  create table
    analytics_dev.model_snapshot_1
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_1/75751c1a-c840-49d8-921b-822df8c7c649',
    format='parquet'
  )
  as
    SELECT * FROM analytics_dev.model_snapshot_1__dbt_tmp_1;

  

  
[0m00:19:39.031957 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:19:39.483240 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_1__dbt_tmp
[0m00:19:39.484189 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:19:40.035958 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_1__dbt_tmp is stored in s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp/ef6e1a53-2c6b-443e-a352-ae72d15cf268/
[0m00:19:40.419201 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:19:40.421522 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:40.423027 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: drop table if exists analytics_dev.model_snapshot_1__dbt_tmp
[0m00:19:41.903737 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:19:42.398253 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_1__dbt_tmp_1
[0m00:19:42.399146 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:19:42.864582 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_1__dbt_tmp_1 is stored in s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp_1/d0c499cf-dd36-417b-ba66-9ee9616dbb7d/
[0m00:19:43.203182 [debug] [Thread-1 (]: Athena adapter: Deleting table data: path='s3://dbt-athena/analytics_dev/model_snapshot_1__dbt_tmp_1/d0c499cf-dd36-417b-ba66-9ee9616dbb7d/', bucket='dbt-athena', prefix='analytics_dev/model_snapshot_1__dbt_tmp_1/d0c499cf-dd36-417b-ba66-9ee9616dbb7d/'
[0m00:19:43.622292 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_1"
[0m00:19:43.623129 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: drop table if exists analytics_dev.model_snapshot_1__dbt_tmp_1
[0m00:19:45.155210 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:45.159113 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_1 (execute): 2023-02-13 00:19:17.183464 => 2023-02-13 00:19:45.159011
[0m00:19:45.159874 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_1: Close
[0m00:19:45.161263 [debug] [Thread-1 (]: Sending event: {'category': 'dbt', 'action': 'run_model', 'label': '4ca07f92-0d0b-4769-bafe-23a2535eb485', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f9981a740>]}
[0m00:19:45.162328 [info ] [Thread-1 (]: 1 of 3 OK snapshotted analytics_dev.model_snapshot_1 ........................... [[32msuccess[0m in 27.99s]
[0m00:19:45.166012 [debug] [Thread-1 (]: Finished running node snapshot.dbt_dev.model_snapshot_1
[0m00:19:45.166883 [debug] [Thread-1 (]: Began running node snapshot.dbt_dev.model_snapshot_2
[0m00:19:45.167866 [info ] [Thread-1 (]: 2 of 3 START snapshot analytics_dev.model_snapshot_2 ........................... [RUN]
[0m00:19:45.169057 [debug] [Thread-1 (]: Acquiring new athena connection 'snapshot.dbt_dev.model_snapshot_2'
[0m00:19:45.170658 [debug] [Thread-1 (]: Began compiling node snapshot.dbt_dev.model_snapshot_2
[0m00:19:45.179122 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_2 (compile): 2023-02-13 00:19:45.171567 => 2023-02-13 00:19:45.179000
[0m00:19:45.179940 [debug] [Thread-1 (]: Began executing node snapshot.dbt_dev.model_snapshot_2
[0m00:19:45.182962 [debug] [Thread-1 (]: Checking if target table exists
[0m00:19:45.188351 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:19:45.189004 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */

    select count(*)
        from "awsdatacatalog".INFORMATION_SCHEMA.SCHEMATA
        where catalog_name='awsdatacatalog'
          and schema_name='analytics_dev'
  
[0m00:19:45.189586 [debug] [Thread-1 (]: Opening a new connection, currently in state closed
[0m00:19:47.362309 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:47.408202 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:19:47.409000 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */
select * from (
            select series_reference, data_value from (


SELECT * from analytics_dev.model
) subq
        ) as __dbt_sbq
        where false
        limit 0
    
[0m00:19:48.960915 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:48.967603 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:19:48.968495 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_2')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:50.464224 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:19:50.471861 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:19:50.472282 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_2')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:51.979538 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:52.420102 [debug] [Thread-1 (]: Athena adapter: Error calling Glue get_table: An error occurred (EntityNotFoundException) when calling the GetTable operation: Table model_snapshot_2__dbt_tmp not found.
[0m00:19:52.747626 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:19:52.748557 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:19:52.749226 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */

        
  
    

  

  create table
    analytics_dev.model_snapshot_2__dbt_tmp
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_2__dbt_tmp/071cdcd0-f629-4e44-8a4f-7a37606ce88b',
    format='parquet'
  )
  as
    WITH snapshot_query AS (
        


SELECT * from analytics_dev.model

    )
    , snapshotted_data_base AS (
        SELECT *
          , ROW_NUMBER() OVER (
              PARTITION BY dbt_unique_key
              ORDER BY dbt_valid_from DESC
            ) AS dbt_snapshot_rn
        FROM analytics_dev.model_snapshot_2
    )
    , snapshotted_data AS (
        SELECT *
        FROM snapshotted_data_base
        WHERE dbt_snapshot_rn = 1
          AND dbt_change_type != 'delete'
    )
    , source_data AS (
        SELECT *
          , id AS dbt_unique_key
          , 
    -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
 AS dbt_valid_from
          , to_hex(md5(to_utf8(coalesce(cast(id as varchar ), '')
         || '|' || coalesce(cast(
    -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
 as varchar ), '')
        ))) AS dbt_scd_id
        FROM snapshot_query
    )
    , upserts AS (
        SELECT source_data.*
          , CASE
              WHEN snapshotted_data.dbt_unique_key IS NULL THEN 'insert'
              ELSE 'update'
            END as dbt_change_type
          , CAST('9999-01-01' as timestamp) AS dbt_valid_to
          , True AS is_current_record
        FROM source_data
        LEFT JOIN snapshotted_data
               ON snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
        WHERE snapshotted_data.dbt_unique_key IS NULL
           OR (
                snapshotted_data.dbt_unique_key IS NOT NULL
            AND (
                (snapshotted_data."series_reference" != source_data."series_reference"
        or
        (
            ((snapshotted_data."series_reference" is null) and not (source_data."series_reference" is null))
            or
            ((not snapshotted_data."series_reference" is null) and (source_data."series_reference" is null))
        ) or snapshotted_data."data_value" != source_data."data_value"
        or
        (
            ((snapshotted_data."data_value" is null) and not (source_data."data_value" is null))
            or
            ((not snapshotted_data."data_value" is null) and (source_data."data_value" is null))
        ))
            )
        )
    )
    SELECT * FROM upserts;
    

  
    
[0m00:19:55.308831 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:19:55.323849 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:19:55.325578 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_2__dbt_tmp')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:56.865346 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:19:56.872562 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:19:56.873415 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_2')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:58.365705 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:19:58.375982 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:19:58.376614 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_2__dbt_tmp')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:19:59.901236 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:20:00.263569 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:20:00.264734 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:20:00.265472 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */

        
  
    

  

  create table
    analytics_dev.model_snapshot_2__dbt_tmp_1
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_2__dbt_tmp_1/5d965b41-f0b9-4ba1-896d-1637e2fb84b9',
    format='parquet'
  )
  as
    SELECT
        
          id,
          series_reference,
          period,
          data_value,
          suppressed,
          refresh_timestamp,
          dbt_unique_key,
          dbt_valid_from,
          dbt_scd_id,
          dbt_change_type,
          dbt_valid_to,
          is_current_record
        ,dbt_snapshot_at
      from analytics_dev.model_snapshot_2
      WHERE dbt_unique_key NOT IN ( SELECT dbt_unique_key FROM analytics_dev.model_snapshot_2__dbt_tmp )
      UNION ALL
      SELECT
        
              
                id,
        
              
                series_reference,
        
              
                period,
        
              
                data_value,
        
              
                suppressed,
        
              
                refresh_timestamp,
        
              
                dbt_unique_key,
        
              
                dbt_valid_from,
        
              
                dbt_scd_id,
        
              
                dbt_change_type,
        
              
              CASE
              WHEN dbt_valid_to=CAST('9999-01-01' as timestamp) AND is_current_record=True
              THEN -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
              ELSE dbt_valid_to
              END AS dbt_valid_to,
        
              
              CASE WHEN is_current_record=True THEN False ELSE is_current_record END
              AS is_current_record
        
        ,-- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
      from analytics_dev.model_snapshot_2
      WHERE dbt_unique_key IN ( SELECT dbt_unique_key FROM analytics_dev.model_snapshot_2__dbt_tmp )
      UNION ALL
      SELECT
        
            id,
            series_reference,
            period,
            data_value,
            suppressed,
            refresh_timestamp,
            dbt_unique_key,
            dbt_valid_from,
            dbt_scd_id,
            dbt_change_type,
            dbt_valid_to,
            is_current_record
        ,-- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
      FROM analytics_dev.model_snapshot_2__dbt_tmp;

  
    
[0m00:20:02.837790 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:20:03.383652 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_2
[0m00:20:03.384571 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:20:03.997305 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_2 is stored in s3://dbt-athena/analytics_dev/model_snapshot_2/cc480d3c-2ffc-4db7-94c9-b8e137d14423/
[0m00:20:04.446264 [debug] [Thread-1 (]: Athena adapter: Deleting table data: path='s3://dbt-athena/analytics_dev/model_snapshot_2/cc480d3c-2ffc-4db7-94c9-b8e137d14423/', bucket='dbt-athena', prefix='analytics_dev/model_snapshot_2/cc480d3c-2ffc-4db7-94c9-b8e137d14423/'
[0m00:20:04.895005 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:20:04.895831 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: drop table if exists analytics_dev.model_snapshot_2
[0m00:20:06.399942 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:20:06.746451 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:20:06.747821 [debug] [Thread-1 (]: Writing runtime sql for node "snapshot.dbt_dev.model_snapshot_2"
[0m00:20:06.748906 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:20:06.749626 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_2"} */

      
  
    

  

  create table
    analytics_dev.model_snapshot_2
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_2/8a7603bc-c3a3-4918-9d99-36efdb02cdf6',
    format='parquet'
  )
  as
    SELECT * FROM analytics_dev.model_snapshot_2__dbt_tmp_1;

  

  
[0m00:20:08.503701 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:20:08.934399 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_2__dbt_tmp
[0m00:20:08.935223 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:20:09.381521 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_2__dbt_tmp is stored in s3://dbt-athena/analytics_dev/model_snapshot_2__dbt_tmp/071cdcd0-f629-4e44-8a4f-7a37606ce88b/
[0m00:20:09.690517 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:20:09.691808 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:20:09.692494 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: drop table if exists analytics_dev.model_snapshot_2__dbt_tmp
[0m00:20:11.169027 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:20:11.676660 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_2__dbt_tmp_1
[0m00:20:11.677500 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:20:12.112863 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_2__dbt_tmp_1 is stored in s3://dbt-athena/analytics_dev/model_snapshot_2__dbt_tmp_1/5d965b41-f0b9-4ba1-896d-1637e2fb84b9/
[0m00:20:12.456487 [debug] [Thread-1 (]: Athena adapter: Deleting table data: path='s3://dbt-athena/analytics_dev/model_snapshot_2__dbt_tmp_1/5d965b41-f0b9-4ba1-896d-1637e2fb84b9/', bucket='dbt-athena', prefix='analytics_dev/model_snapshot_2__dbt_tmp_1/5d965b41-f0b9-4ba1-896d-1637e2fb84b9/'
[0m00:20:12.876449 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_2"
[0m00:20:12.877289 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: drop table if exists analytics_dev.model_snapshot_2__dbt_tmp_1
[0m00:20:14.384805 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:20:14.390328 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_2 (execute): 2023-02-13 00:19:45.180516 => 2023-02-13 00:20:14.389842
[0m00:20:14.391928 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_2: Close
[0m00:20:14.393870 [debug] [Thread-1 (]: Sending event: {'category': 'dbt', 'action': 'run_model', 'label': '4ca07f92-0d0b-4769-bafe-23a2535eb485', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f93449ae0>]}
[0m00:20:14.396354 [info ] [Thread-1 (]: 2 of 3 OK snapshotted analytics_dev.model_snapshot_2 ........................... [[32msuccess[0m in 29.23s]
[0m00:20:14.401368 [debug] [Thread-1 (]: Finished running node snapshot.dbt_dev.model_snapshot_2
[0m00:20:14.407409 [debug] [Thread-1 (]: Began running node snapshot.dbt_dev.model_snapshot_3
[0m00:20:14.408671 [info ] [Thread-1 (]: 3 of 3 START snapshot analytics_dev.model_snapshot_3 ........................... [RUN]
[0m00:20:14.409745 [debug] [Thread-1 (]: Acquiring new athena connection 'snapshot.dbt_dev.model_snapshot_3'
[0m00:20:14.410865 [debug] [Thread-1 (]: Began compiling node snapshot.dbt_dev.model_snapshot_3
[0m00:20:14.418652 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_3 (compile): 2023-02-13 00:20:14.411372 => 2023-02-13 00:20:14.418473
[0m00:20:14.419706 [debug] [Thread-1 (]: Began executing node snapshot.dbt_dev.model_snapshot_3
[0m00:20:14.423731 [debug] [Thread-1 (]: Checking if target table exists
[0m00:20:14.429665 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:14.430589 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */

    select count(*)
        from "awsdatacatalog".INFORMATION_SCHEMA.SCHEMATA
        where catalog_name='awsdatacatalog'
          and schema_name='analytics_dev'
  
[0m00:20:14.431464 [debug] [Thread-1 (]: Opening a new connection, currently in state closed
[0m00:20:16.270640 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:20:16.276665 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:16.277038 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_3')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:20:19.050160 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:20:19.527698 [debug] [Thread-1 (]: Athena adapter: Error calling Glue get_table: An error occurred (EntityNotFoundException) when calling the GetTable operation: Table model_snapshot_3__dbt_tmp not found.
[0m00:20:19.534890 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:19.535626 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_3')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:20:21.029673 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:20:21.385272 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:20:21.386243 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:21.386923 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */

        
  
    

  

  create table
    analytics_dev.model_snapshot_3__dbt_tmp
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_3__dbt_tmp/a317d7be-c853-45b3-bc8c-c7b6f61cdaca',
    format='parquet'
  )
  as
    WITH snapshot_query AS (
        


SELECT * from analytics_dev.model

    )
    , snapshotted_data_base AS (
        SELECT *
          , ROW_NUMBER() OVER (
              PARTITION BY dbt_unique_key
              ORDER BY dbt_valid_from DESC
            ) AS dbt_snapshot_rn
        FROM analytics_dev.model_snapshot_3
    )
    , snapshotted_data AS (
        SELECT *
        FROM snapshotted_data_base
        WHERE dbt_snapshot_rn = 1
          AND dbt_change_type != 'delete'
    )
    , source_data AS (
        SELECT *
          , id AS dbt_unique_key
          , refresh_timestamp AS dbt_valid_from
          , to_hex(md5(to_utf8(coalesce(cast(id as varchar ), '')
         || '|' || coalesce(cast(refresh_timestamp as varchar ), '')
        ))) AS dbt_scd_id
        FROM snapshot_query
    )
    , upserts AS (
        SELECT source_data.*
          , CASE
              WHEN snapshotted_data.dbt_unique_key IS NULL THEN 'insert'
              ELSE 'update'
            END as dbt_change_type
          , CAST('9999-01-01' as timestamp) AS dbt_valid_to
          , True AS is_current_record
        FROM source_data
        LEFT JOIN snapshotted_data
               ON snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
        WHERE snapshotted_data.dbt_unique_key IS NULL
           OR (
                snapshotted_data.dbt_unique_key IS NOT NULL
            AND (
                (snapshotted_data.dbt_valid_from < source_data.refresh_timestamp)
            )
        )
    ), deletes AS (
        SELECT
        
          
            snapshotted_data.id,
        
          
            snapshotted_data.series_reference,
        
          
            snapshotted_data.period,
        
          
            snapshotted_data.data_value,
        
          
            snapshotted_data.suppressed,
        
          
            snapshotted_data.refresh_timestamp,
        
          
            snapshotted_data.dbt_unique_key,
        
          
            -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_valid_from,
        
          
            snapshotted_data.dbt_scd_id,
        
          
            'delete' AS dbt_change_type,
        
          
            CAST('9999-01-01' as timestamp) AS dbt_valid_to,
        
          
            True AS is_current_record
        
        FROM snapshotted_data
        LEFT JOIN source_data
               ON snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
        WHERE source_data.dbt_unique_key IS NULL
    )
    SELECT * FROM upserts
    UNION ALL
    SELECT * FROM deletes;
    

  
    
[0m00:20:24.068405 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:20:24.074735 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:24.075668 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_3__dbt_tmp')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:20:25.548240 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:20:25.555754 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:25.556652 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_3')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:20:27.089961 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:20:27.099282 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:27.100027 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */


      select
          column_name,
          data_type,
          null as character_maximum_length,
          null as numeric_precision,
          null as numeric_scale

      from "awsdatacatalog".INFORMATION_SCHEMA.columns
      where table_name = LOWER('model_snapshot_3__dbt_tmp')
        
            and table_schema = LOWER('analytics_dev')
        
      order by ordinal_position

  
[0m00:20:28.583697 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:20:28.942715 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:20:28.943695 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:28.944389 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */

        
  
    

  

  create table
    analytics_dev.model_snapshot_3__dbt_tmp_1
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_3__dbt_tmp_1/066c35e1-6738-4c19-9a8d-bce1e97d260a',
    format='parquet'
  )
  as
    SELECT
        
          id,
          series_reference,
          period,
          data_value,
          suppressed,
          refresh_timestamp,
          dbt_unique_key,
          dbt_valid_from,
          dbt_scd_id,
          dbt_change_type,
          dbt_valid_to,
          is_current_record
        ,dbt_snapshot_at
      from analytics_dev.model_snapshot_3
      WHERE dbt_unique_key NOT IN ( SELECT dbt_unique_key FROM analytics_dev.model_snapshot_3__dbt_tmp )
      UNION ALL
      SELECT
        
              
                id,
        
              
                series_reference,
        
              
                period,
        
              
                data_value,
        
              
                suppressed,
        
              
                refresh_timestamp,
        
              
                dbt_unique_key,
        
              
                dbt_valid_from,
        
              
                dbt_scd_id,
        
              
                dbt_change_type,
        
              
              CASE
              WHEN dbt_valid_to=CAST('9999-01-01' as timestamp) AND is_current_record=True
              THEN -- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp)
              ELSE dbt_valid_to
              END AS dbt_valid_to,
        
              
              CASE WHEN is_current_record=True THEN False ELSE is_current_record END
              AS is_current_record
        
        ,-- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
      from analytics_dev.model_snapshot_3
      WHERE dbt_unique_key IN ( SELECT dbt_unique_key FROM analytics_dev.model_snapshot_3__dbt_tmp )
      UNION ALL
      SELECT
        
            id,
            series_reference,
            period,
            data_value,
            suppressed,
            refresh_timestamp,
            dbt_unique_key,
            dbt_valid_from,
            dbt_scd_id,
            dbt_change_type,
            dbt_valid_to,
            is_current_record
        ,-- pyathena converts time zoned timestamps to strings so lets avoid them
    -- now()
    cast(now() as timestamp) AS dbt_snapshot_at
      FROM analytics_dev.model_snapshot_3__dbt_tmp;

  
    
[0m00:20:31.471856 [debug] [Thread-1 (]: SQL status: OK -1 in 3 seconds
[0m00:20:31.965445 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_3
[0m00:20:31.966506 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:20:32.465536 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_3 is stored in s3://dbt-athena/analytics_dev/model_snapshot_3/da32de04-55f1-4817-8a8e-fea2763f6876/
[0m00:20:32.864646 [debug] [Thread-1 (]: Athena adapter: Deleting table data: path='s3://dbt-athena/analytics_dev/model_snapshot_3/da32de04-55f1-4817-8a8e-fea2763f6876/', bucket='dbt-athena', prefix='analytics_dev/model_snapshot_3/da32de04-55f1-4817-8a8e-fea2763f6876/'
[0m00:20:33.311429 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:33.312541 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: drop table if exists analytics_dev.model_snapshot_3
[0m00:20:34.826539 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:20:35.152461 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:20:35.153674 [debug] [Thread-1 (]: Writing runtime sql for node "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:35.154743 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:35.155450 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: -- /* {"app": "dbt", "dbt_version": "1.4.1", "profile_name": "analytics_dev", "target_name": "dev", "node_id": "snapshot.dbt_dev.model_snapshot_3"} */

      
  
    

  

  create table
    analytics_dev.model_snapshot_3
  with (
    table_type='hive',
    is_external=true,
    external_location='s3://dbt-athena/analytics_dev/model_snapshot_3/eccbcd58-c1aa-4bc6-b928-1ced2a303be2',
    format='parquet'
  )
  as
    SELECT * FROM analytics_dev.model_snapshot_3__dbt_tmp_1;

  

  
[0m00:20:36.632113 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:20:37.058396 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_3__dbt_tmp
[0m00:20:37.059224 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:20:37.519722 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_3__dbt_tmp is stored in s3://dbt-athena/analytics_dev/model_snapshot_3__dbt_tmp/a317d7be-c853-45b3-bc8c-c7b6f61cdaca/
[0m00:20:37.856873 [debug] [Thread-1 (]: Athena adapter: S3 path does not exist
[0m00:20:37.858422 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:37.859000 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: drop table if exists analytics_dev.model_snapshot_3__dbt_tmp
[0m00:20:39.433811 [debug] [Thread-1 (]: SQL status: OK -1 in 2 seconds
[0m00:20:39.924812 [debug] [Thread-1 (]: Athena adapter: table_name : model_snapshot_3__dbt_tmp_1
[0m00:20:39.925702 [debug] [Thread-1 (]: Athena adapter: table type : table
[0m00:20:40.409327 [debug] [Thread-1 (]: Athena adapter: analytics_dev.model_snapshot_3__dbt_tmp_1 is stored in s3://dbt-athena/analytics_dev/model_snapshot_3__dbt_tmp_1/066c35e1-6738-4c19-9a8d-bce1e97d260a/
[0m00:20:40.764972 [debug] [Thread-1 (]: Athena adapter: Deleting table data: path='s3://dbt-athena/analytics_dev/model_snapshot_3__dbt_tmp_1/066c35e1-6738-4c19-9a8d-bce1e97d260a/', bucket='dbt-athena', prefix='analytics_dev/model_snapshot_3__dbt_tmp_1/066c35e1-6738-4c19-9a8d-bce1e97d260a/'
[0m00:20:41.160072 [debug] [Thread-1 (]: Using athena connection "snapshot.dbt_dev.model_snapshot_3"
[0m00:20:41.160926 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: drop table if exists analytics_dev.model_snapshot_3__dbt_tmp_1
[0m00:20:42.606011 [debug] [Thread-1 (]: SQL status: OK -1 in 1 seconds
[0m00:20:42.609675 [debug] [Thread-1 (]: Timing info for snapshot.dbt_dev.model_snapshot_3 (execute): 2023-02-13 00:20:14.420419 => 2023-02-13 00:20:42.609569
[0m00:20:42.610502 [debug] [Thread-1 (]: On snapshot.dbt_dev.model_snapshot_3: Close
[0m00:20:42.612047 [debug] [Thread-1 (]: Sending event: {'category': 'dbt', 'action': 'run_model', 'label': '4ca07f92-0d0b-4769-bafe-23a2535eb485', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f911a4790>]}
[0m00:20:42.613172 [info ] [Thread-1 (]: 3 of 3 OK snapshotted analytics_dev.model_snapshot_3 ........................... [[32msuccess[0m in 28.20s]
[0m00:20:42.613990 [debug] [Thread-1 (]: Finished running node snapshot.dbt_dev.model_snapshot_3
[0m00:20:42.616842 [debug] [MainThread]: Acquiring new athena connection 'master'
[0m00:20:42.618183 [debug] [MainThread]: Connection 'master' was properly closed.
[0m00:20:42.618913 [debug] [MainThread]: Connection 'snapshot.dbt_dev.model_snapshot_3' was properly closed.
[0m00:20:42.620655 [info ] [MainThread]: 
[0m00:20:42.621512 [info ] [MainThread]: Finished running 3 snapshots in 0 hours 1 minutes and 28.03 seconds (88.03s).
[0m00:20:42.622925 [debug] [MainThread]: Command end result
[0m00:20:42.634945 [info ] [MainThread]: 
[0m00:20:42.635991 [info ] [MainThread]: [32mCompleted successfully[0m
[0m00:20:42.636779 [info ] [MainThread]: 
[0m00:20:42.637434 [info ] [MainThread]: Done. PASS=3 WARN=0 ERROR=0 SKIP=0 TOTAL=3
[0m00:20:42.638405 [debug] [MainThread]: Sending event: {'category': 'dbt', 'action': 'invocation', 'label': 'end', 'context': [<snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f932d5ab0>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f9981a740>, <snowplow_tracker.self_describing_json.SelfDescribingJson object at 0x7f7f90e0b2e0>]}
[0m00:20:42.639528 [debug] [MainThread]: Flushing usage events
```
</details>


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
