### PR TITLE
fix: improve clean-up table

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -127,6 +127,7 @@ class AthenaAdapter(SQLAdapter):
         # Look up Glue partitions & clean up
         conn = self.connections.get_thread_connection()
         client = conn.handle
+        table = None
         with boto3_client_lock:
             glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
         try:
@@ -138,7 +139,8 @@ class AthenaAdapter(SQLAdapter):
 
         if table is not None:
             s3_location = table["Table"]["StorageDescriptor"]["Location"]
-            self._delete_from_s3(client, s3_location)
+            if s3_location:
+                self._delete_from_s3(client, s3_location)
 
     @available
     def prune_s3_table_location(self, s3_table_location: str):


### PR DESCRIPTION
### Description

This should fix the issue raised on https://github.com/dbt-athena/dbt-athena/issues/113
When a model was originally a view, and then switched to a table `table["Table"]["StorageDescriptor"]["Location"]` is empty. Therefore we try pass an empty string downstream, that lead to a "invalid bucket"  

I was not able to fully reproduced what was raised in the ticket, but anyhow this PR add a safeguard, where _delete_from_s3 is called when location is not empty

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [ ] You added functional testing when necessary
