### PR TITLE
chore: refactor boto3 calls and expose more functions

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -36,9 +36,7 @@
     {%- endif -%}
   {%- endif %}
 
-{%- if table_type != 'iceberg' -%}
-    {% do adapter.prune_s3_table_location(location) %}
-{%- endif -%}
+  {% do adapter.delete_from_s3(location) %}
 
   create table
     {{ relation }}

--- a/tests/unit/constants.py
+++ b/tests/unit/constants.py
@@ -1,5 +1,5 @@
 CATALOG_ID = "catalog_id"
 DATA_CATALOG_NAME = "awsdatacatalog"
 DATABASE_NAME = "test_dbt_athena"
-BUCKET = "test-dbt-athena-test-delete-partitions"
+BUCKET = "test-dbt-athena"
 AWS_REGION = "eu-west-1"


### PR DESCRIPTION
### Description

This PR aim to create separate clients for each AWS SDK call, doing so we avoid to leave open connections.
It also introduce get_table_location  and make `delete_from_s3` method available (to use in some custom macros=




## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
- [x]  You run manually functional testing
