### PR TITLE
fix: allow optimize commands

### DIFF
--- a/dbt/adapters/athena/query_headers.py
+++ b/dbt/adapters/athena/query_headers.py
@@ -16,7 +16,7 @@ class _QueryComment(dbt.adapters.base.query_headers._QueryComment):
 
         # alter or vacuum statements don't seem to support properly query comments
         # let's just exclude them
-        if any(map(sql.lower().__contains__, ["alter", "drop", "vacuum"])):
+        if any(map(sql.lower().__contains__, ["alter", "drop", "optimize", "vacuum"])):
             return sql
 
         cleaned_query_comment = self.query_comment.strip().replace("\n", " ")

--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -31,6 +31,17 @@ class AthenaRelation(BaseRelation):
         object.__setattr__(self, "quote_character", old_value)
         return rendered
 
+    def render_pure(self):
+        """
+        Render relation without quotes characters.
+        This is needed for not standard executions like optimize and vacuum
+        """
+        old_value = self.quote_character
+        object.__setattr__(self, "quote_character", "")
+        rendered = self.render()
+        object.__setattr__(self, "quote_character", old_value)
+        return rendered
+
 
 class AthenaSchemaSearchMap(Dict[InformationSchema, Dict[str, Set[Optional[str]]]]):
     """A utility class to keep track of what information_schema tables to

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ Flake8-pyproject~=1.2
 isort~=5.11
 moto~=4.1.3
 pre-commit~=2.21
+pyparsing~=3.0.9
 pytest~=7.2
 pytest-cov~=4.0
 pyupgrade~=3.3

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -22,3 +22,11 @@ class TestAthenaRelation:
         )
         relation.render_hive()
         assert relation.render() == f'"{DATABASE_NAME}"."{TABLE_NAME}"'
+
+    def test_render_pure_resets_quote_character_after_call(self):
+        relation = AthenaRelation.create(
+            identifier=TABLE_NAME,
+            database=DATA_CATALOG_NAME,
+            schema=DATABASE_NAME,
+        )
+        assert relation.render_pure() == f"{DATABASE_NAME}.{TABLE_NAME}"


### PR DESCRIPTION
### Description

Optimize commands and vacuum need to be excluded from query header, but also they require rendering without quotes.
This PR add a simple function called `render_pure` that can be call when needed.



## Example
Tested with post_hooks

```
 post_hook = [
        """
        optimize {{this.render_pure()}} rewrite data using bin_pack
        """
    ]
```
Calling the method render_pure on the relation avoid to have quotes of any type, and let the command going through. 



## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
