### PR TITLE
fix: Render relation in Hive format for materialized='table_hive_ha'

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table_hive_ha.sql
@@ -39,7 +39,7 @@
 
     -- drop the tmp_relation
     {% call statement('drop_tmp_relation', auto_begin=False) -%}
-      drop table if exists {{ tmp_relation }}
+      drop table if exists {{ tmp_relation.render_hive() }}
     {%- endcall %}
 
     -- create tmp table
@@ -55,7 +55,7 @@
 
     -- delete glue tmp table, do not use drop_relation, as it will remove data of the target table
     {% call statement('drop_tmp_relation', auto_begin=False) -%}
-      drop table if exists {{ tmp_relation }}
+      drop table if exists {{ tmp_relation.render_hive() }}
     {%- endcall %}
 
     {% set result_table_version_expiration = adapter.expire_glue_table_versions(target_relation.schema, target_relation.table, versions_to_keep, True) %}


### PR DESCRIPTION
### Description

I was just testing #128  but encountered an issue.

I was trying to create a model `test.sql` within the schema `migration_test`

But that would throw me an error which seemed weird.

`botocore.errorfactory.InvalidRequestException: An error occurred (InvalidRequestException) when calling the StartQueryExecution operation: line 1:22: mismatched input '"migration_test"' expecting `

I was able to fix it by adding a `.render_hive()` to the `tmp_relation`s in the DDL queries within the new `table_hive_ha.sql`

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

```
{{ config(
    materialized='table_hive_ha',
    s3_data_naming='schema_table_unique'
) }}

select 
    2 as inte
    , cast('2022-12-12 12:12:12' as timestamp) as ts
    , 'asd' as str
    , 2.2 as double
    , 1=1 as bool

```

## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
