### PR TITLE
fix: allow schema/database to not exist when listing relations

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -321,7 +321,7 @@ class AthenaAdapter(SQLAdapter):
                     )
         except ClientError as e:
             # don't error out when schema doesn't exist
-            # this allows for dbt creating and managing schemas/databases
+            # this allows dbt to create and manage schemas/databases
             logger.debug(f"Schema '{schema_relation.schema}' does not exist - Ignoring: {e}")
 
         return relations

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -297,27 +297,32 @@ class AthenaAdapter(SQLAdapter):
         relations = []
         quote_policy = {"database": True, "schema": True, "identifier": True}
 
-        for page in page_iterator:
-            tables = page["TableList"]
-            for table in tables:
-                if "TableType" not in table:
-                    logger.debug(f"Table '{table['Name']}' has no TableType attribute - Ignoring")
-                    continue
-                _type = table["TableType"]
-                if _type == "VIRTUAL_VIEW":
-                    _type = self.Relation.View
-                else:
-                    _type = self.Relation.Table
+        try:
+            for page in page_iterator:
+                tables = page["TableList"]
+                for table in tables:
+                    if "TableType" not in table:
+                        logger.debug(f"Table '{table['Name']}' has no TableType attribute - Ignoring")
+                        continue
+                    _type = table["TableType"]
+                    if _type == "VIRTUAL_VIEW":
+                        _type = self.Relation.View
+                    else:
+                        _type = self.Relation.Table
 
-                relations.append(
-                    self.Relation.create(
-                        schema=schema_relation.schema,
-                        database=schema_relation.database,
-                        identifier=table["Name"],
-                        quote_policy=quote_policy,
-                        type=_type,
+                    relations.append(
+                        self.Relation.create(
+                            schema=schema_relation.schema,
+                            database=schema_relation.database,
+                            identifier=table["Name"],
+                            quote_policy=quote_policy,
+                            type=_type,
+                        )
                     )
-                )
+        except ClientError as e:
+            # don't error out when schema doesn't exist
+            # this allows for dbt creating and managing schemas/databases
+            logger.debug(f"Schema '{schema_relation.schema}' does not exist - Ignoring: {e}")
 
         return relations
 


### PR DESCRIPTION
### Description

Fixes `An error occurred (EntityNotFoundException) when calling the GetTables operation: Database my_db not found.` when listing relations. This assumes that the database already exists at runtime. 

This fix returns an empty relation when the database doesn't exist, similar to the default implementation in `dbt-core`. This allows for dbt to create schemas/databases and manage them.

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
