### PR TITLE
feat: add persist_docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     * Does **not** support the use of `unique_key`
 * Supports [snapshots][snapshots]
 * Does not support [Python models][python-models]
+* Does not support [persist docs][persist-docs] for views
 
 [seeds]: https://docs.getdbt.com/docs/building-a-dbt-project/seeds
 [incremental]: https://docs.getdbt.com/docs/build/incremental-models
@@ -28,6 +29,7 @@
 [python-models]: https://docs.getdbt.com/docs/build/python-models#configuring-python-models
 [athena-iceberg]: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
 [snapshots]: https://docs.getdbt.com/docs/build/snapshots
+[persist-docs]: https://docs.getdbt.com/reference/resource-configs/persist_docs
 
 ### Installation
 

--- a/dbt/adapters/athena/utils.py
+++ b/dbt/adapters/athena/utils.py
@@ -1,0 +1,3 @@
+def clean_sql_comment(comment: str) -> str:
+    split_and_strip = [line.strip() for line in comment.split("\n")]
+    return " ".join(line for line in split_and_strip if line)

--- a/dbt/include/athena/macros/adapters/persist_docs.sql
+++ b/dbt/include/athena/macros/adapters/persist_docs.sql
@@ -1,0 +1,10 @@
+{% macro athena__persist_docs(relation, model, for_relation, for_columns) -%}
+  {% set persist_relation_docs = for_relation and config.persist_relation_docs() and model.description %}
+  {% set persist_column_docs = for_columns and config.persist_column_docs() and model.columns %}
+  {% if (persist_relation_docs or persist_column_docs) and relation.type != 'view' %}
+    {% do adapter.persist_docs_to_glue(relation,
+                                       model,
+                                       persist_relation_docs,
+                                       persist_column_docs) %}}
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/athena/macros/materializations/models/view/view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/view.sql
@@ -2,7 +2,6 @@
     {% set to_return = create_or_replace_view(run_outside_transaction_hooks=False) %}
 
     {% set target_relation = this.incorporate(type='view') %}
-    {% do persist_docs(target_relation, model) %}
 
     {% do return(to_return) %}
 {%- endmaterialization %}

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -666,6 +666,89 @@ class TestAthenaAdapter:
         # TODO moto issue https://github.com/getmoto/moto/issues/5952
         # assert len(result) == 3
 
+    @mock_athena
+    @mock_glue
+    @mock_s3
+    def test_persist_docs_to_glue_no_comment(self):
+        self.mock_aws_service.create_data_catalog()
+        self.mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        table_name = "my_table"
+        self.mock_aws_service.create_table(table_name)
+        schema_relation = self.adapter.Relation.create(
+            database=DATA_CATALOG_NAME,
+            schema=DATABASE_NAME,
+            identifier=table_name,
+        )
+        self.adapter.persist_docs_to_glue(
+            schema_relation,
+            {
+                "description": """
+                        A table with str, 123, &^% \" and '
+
+                          and an other paragraph.
+                    """,
+                "columns": {
+                    "id": {
+                        "description": """
+                        A column with str, 123, &^% \" and '
+
+                          and an other paragraph.
+                    """,
+                    }
+                },
+            },
+            False,
+            False,
+        )
+        glue = boto3.client("glue", region_name=AWS_REGION)
+        table = glue.get_table(DatabaseName=DATABASE_NAME, Name=table_name).get("Table")
+        assert not table.get("Description", "")
+        assert not table["Parameters"].get("comment")
+        assert all(not col.get("Comment") for col in table["StorageDescriptor"]["Columns"])
+
+    @mock_athena
+    @mock_glue
+    @mock_s3
+    def test_persist_docs_to_glue_comment(self):
+        self.mock_aws_service.create_data_catalog()
+        self.mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        table_name = "my_table"
+        self.mock_aws_service.create_table(table_name)
+        schema_relation = self.adapter.Relation.create(
+            database=DATA_CATALOG_NAME,
+            schema=DATABASE_NAME,
+            identifier=table_name,
+        )
+        self.adapter.persist_docs_to_glue(
+            schema_relation,
+            {
+                "description": """
+                        A table with str, 123, &^% \" and '
+
+                          and an other paragraph.
+                    """,
+                "columns": {
+                    "id": {
+                        "description": """
+                        A column with str, 123, &^% \" and '
+
+                          and an other paragraph.
+                    """,
+                    }
+                },
+            },
+            True,
+            True,
+        )
+        glue = boto3.client("glue", region_name=AWS_REGION)
+        table = glue.get_table(DatabaseName=DATABASE_NAME, Name=table_name).get("Table")
+        assert table["Description"] == "A table with str, 123, &^% \" and ' and an other paragraph."
+        assert table["Parameters"]["comment"] == "A table with str, 123, &^% \" and ' and an other paragraph."
+        col_id = [col for col in table["StorageDescriptor"]["Columns"] if col["Name"] == "id"][0]
+        assert col_id["Comment"] == "A column with str, 123, &^% \" and ' and an other paragraph."
+
 
 class TestAthenaFilterCatalog:
     def test__catalog_filter_table(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,14 @@
+from dbt.adapters.athena.utils import clean_sql_comment
+
+
+def test_clean_comment():
+    assert (
+        clean_sql_comment(
+            """
+       my long comment
+         on several lines
+        with weird spaces and indents.
+    """
+        )
+        == "my long comment on several lines with weird spaces and indents."
+    )


### PR DESCRIPTION
### Description

Closes #167 

Add the feature of persisting docs in Athena / Glue. This is possible using the `update_table` feature of Glue API. This feature is not supported for views because Athena does not support comment for view.

## Models used to test - Optional
- `seeds/schema.yml`
```yaml
version: 2

seeds:
  - name: countries
    description: A mapping of two letter country codes to country names
    columns:
      - name: country_code
        description: The ISO code
        tests:
          - unique
          - not_null
      - name: country_name
        tests:
          - unique
          - not_null
```

- `seeds/countries.csv`
```csv
country_code,country_name
US,United States
CA,Canada
GB,United Kingdom
```

- `models/schema.yml`
```yaml
version: 2

models:
  - name: persist_docs_table
    description: |
      A test table to check whether or not we need to adjust persist doc. 
      I can try to put simple quote ' or even double quotes " or something more exotic like
      figures 123 or special characters like &^%
      
      And I also tried to make an other paragraph.
      
      And an other one.
    columns:
      - name: ts
        description: |
          The timestamp of the table. It is important to also test that we can add figures 123 or 
          even simple quotes ' or even double quotes " or even special characters like &*^ or so.

  - name: persist_docs_view
    description: |
      A test table to check whether or not we need to adjust persist doc. 
      I can try to put simple quote ' or even double quotes " or something more exotic like
      figures 123 or special characters like &^%
    columns:
      - name: one
        description: |
          It is important to also test that we can add figures 123 or even simple quotes ' or even 
          double quotes " or even special characters like &*^ or so.
      - name: two
        description: |
          It is important to also test that we can add figures 123 or even simple quotes ' or even 
          double quotes " or even special characters like &*^ or so.

  - name: persist_docs_iceberg
    description: |
      A test table to check whether or not we need to adjust persist doc. 
      I can try to put simple quote ' or even double quotes " or something more exotic like
      figures 123 or special characters like &^%
    columns:
      - name: ts
        description: |
          The timestamp of the table. It is important to also test that we can add figures 123 or 
          even simple quotes ' or even double quotes " or even special characters like &*^ or so.

  - name: persist_docs_incremental
    description: |
      A test table to check whether or not we need to adjust persist doc. 
      I can try to put simple quote ' or even double quotes " or something more exotic like
      figures 123 or special characters like &^%
    columns:
      - name: ts
        description: |
          The timestamp of the table. It is important to also test that we can add figures 123 or 
          even simple quotes ' or even double quotes " or even special characters like &*^ or so.
      - name: str
        description: A static column
```

- `models/persist_docs_iceberg.sql`
```sql
{{ config(
  materialized='table',
  table_type='iceberg',
  table_properties={
    'vacuum_max_snapshot_age_seconds': '86400',
    'optimize_rewrite_delete_file_threshold': '2'
  }
) }}

SELECT cast(t.ts AS timestamp(6)) AS ts
FROM
    unnest(
        sequence(
            current_date - INTERVAL '1' DAY,
            cast(REPLACE(cast(current_timestamp as varchar), ' UTC', '') as timestamp(6)),
            INTERVAL '1' MINUTE
        )
    ) AS t(ts)
```

- `models/persist_docs_incremental.sql`
```sql
{{ config(
  materialized='incremental',
  incremental_strategy='append',
  format='avro'
) }}

SELECT
    ts
    , 'abc' AS str
FROM {{ ref('persist_docs_table') }}
{% if is_incremental() %}
  -- this filter will only be applied on an incremental run
  WHERE ts > (SELECT max(ts) FROM {{ this }})
{% endif %}
```

- `models/persist_docs_table.sql`
```sql
{{ config(
  materialized='table'
) }}

SELECT cast(t.ts AS timestamp(3)) AS ts
FROM
    unnest(
        sequence(
            current_date - INTERVAL '1' DAY,
            cast(REPLACE(cast(current_timestamp as varchar), ' UTC', '') as timestamp(3)),
            INTERVAL '1' MINUTE
        )
    ) AS t(ts)
```

- `models/persist_docs_view.sql`
```sql
{{ config(
  materialized='view'
) }}

select 1 as one, 'a' as two
```

## Checklist
- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
