### PR TITLE
fix: add render hive in alter statements

### DIFF
--- a/dbt/include/athena/macros/materializations/models/incremental/column_helpers.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/column_helpers.sql
@@ -4,7 +4,7 @@
   {% endif %}
 
   {% set sql -%}
-      alter {{ relation.type }} {{ relation }}
+      alter {{ relation.type }} {{ relation.render_hive() }}
           add columns (
             {%- for column in add_columns -%}
                 {{ column.name }} {{ ddl_data_type(column.data_type) }}{{ ', ' if not loop.last }}
@@ -24,7 +24,7 @@
 
   {%- for column in remove_columns -%}
     {% set sql -%}
-      alter {{ relation.type }} {{ relation }} drop column {{ column.name }}
+      alter {{ relation.type }} {{ relation.render_hive() }} drop column {{ column.name }}
     {% endset %}
     {% do run_query(sql) %}
   {%- endfor -%}
@@ -36,7 +36,7 @@
   {% endif %}
 
   {% set sql -%}
-      alter {{ relation.type }} {{ relation }}
+      alter {{ relation.type }} {{ relation.render_hive() }}
           replace columns (
             {%- for column in replace_columns -%}
                 {{ column.name }} {{ ddl_data_type(column.data_type) }}{{ ', ' if not loop.last }}


### PR DESCRIPTION
### Description

fix https://github.com/dbt-athena/dbt-athena/issues/172 

alert statements must use `render_hive()` to escape the table with a backtick

## Models used to test - Optional

run first this model

```
{{ config(
    materialized='incremental',
    incremental_strategy='merge',
    unique_key='user_id',
    table_type='iceberg',
    on_schema_change='append_new_columns',
    table_properties={
        'vacuum_max_snapshot_age_seconds': '86400',
    	'optimize_rewrite_delete_file_threshold': '2'
    }
) }}

select
    'a' as user_id,
    {{ current_timestamp() }} as updated_at,
    {{ current_timestamp() }} as inserted_at
```

then run this model

```
{{ config(
    materialized='incremental',
    incremental_strategy='merge',
    unique_key='user_id',
    table_type='iceberg',
    on_schema_change='append_new_columns',
    table_properties={
        'vacuum_max_snapshot_age_seconds': '86400',
    	'optimize_rewrite_delete_file_threshold': '2'
    }
) }}

select
    'a' as user_id,
    'test' as new_col,
    {{ current_timestamp() }} as updated_at,
    {{ current_timestamp() }} as inserted_at
```
The col new_col will be added

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
