### PR TITLE
feat: use glue api instead of information_schema to retrieve table info

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -12,8 +12,7 @@ from dbt.adapters.athena import AthenaConnectionManager
 from dbt.adapters.athena.config import get_boto3_config
 from dbt.adapters.athena.relation import AthenaRelation, AthenaSchemaSearchMap
 from dbt.adapters.athena.utils import clean_sql_comment
-from dbt.adapters.base import available
-from dbt.adapters.base.impl import GET_CATALOG_MACRO_NAME
+from dbt.adapters.base import Column, available
 from dbt.adapters.base.relation import BaseRelation, InformationSchema
 from dbt.adapters.sql import SQLAdapter
 from dbt.contracts.graph.manifest import Manifest
@@ -253,15 +252,43 @@ class AthenaAdapter(SQLAdapter):
         schemas: Dict[str, Optional[Set[str]]],
         manifest: Manifest,
     ) -> agate.Table:
-        kwargs = {"information_schema": information_schema, "schemas": schemas}
-        table = self.execute_macro(
-            GET_CATALOG_MACRO_NAME,
-            kwargs=kwargs,
-            # pass in the full manifest so we get any local project
-            # overrides
-            manifest=manifest,
-        )
+        conn = self.connections.get_thread_connection()
+        client = conn.handle
 
+        with boto3_client_lock:
+            glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
+
+        catalog = []
+        paginator = glue_client.get_paginator("get_tables")
+        for schema, relations in schemas.items():
+            for page in paginator.paginate(DatabaseName=schema, MaxResults=100):
+                for table in page["TableList"]:
+                    if table["Name"] in relations:
+                        table_catalog = {
+                            "table_database": conn.credentials.database,
+                            "table_schema": table["DatabaseName"],
+                            "table_name": table["Name"],
+                            "table_type": self.relation_type_map[table["TableType"]],
+                            "table_comment": table.get("Parameters", {}).get("comment", table.get("Description", "")),
+                        }
+                        catalog.extend(
+                            [
+                                {
+                                    **table_catalog,
+                                    **{
+                                        "column_name": col["Name"],
+                                        "column_index": idx,
+                                        "column_type": col["Type"],
+                                        "column_comment": col.get("Comment", ""),
+                                    },
+                                }
+                                for idx, col in enumerate(
+                                    table["StorageDescriptor"]["Columns"] + table.get("PartitionKeys", [])
+                                )
+                            ]
+                        )
+
+        table = agate.Table.from_object(catalog)
         filtered_table = self._catalog_filter_table(table, manifest)
         return self._join_catalog_table_owners(filtered_table, manifest)
 
@@ -511,3 +538,30 @@ class AthenaAdapter(SQLAdapter):
                     col_obj["Comment"] = clean_sql_comment(col_comment)
 
         glue_client.update_table(DatabaseName=relation.schema, TableInput=updated_table)
+
+    @available
+    def list_schemas(self, database: str) -> List[str]:
+        conn = self.connections.get_thread_connection()
+        client = conn.handle
+
+        with boto3_client_lock:
+            glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
+
+        paginator = glue_client.get_paginator("get_databases")
+        result = []
+        for page in paginator.paginate():
+            result.extend([schema["Name"] for schema in page["DatabaseList"]])
+        return result
+
+    @available
+    def get_columns_in_relation(self, relation: AthenaRelation) -> List[Column]:
+        conn = self.connections.get_thread_connection()
+        client = conn.handle
+
+        with boto3_client_lock:
+            glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
+
+        table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.identifier)["Table"]
+        return [
+            Column(c["Name"], c["Type"]) for c in table["StorageDescriptor"]["Columns"] + table.get("PartitionKeys", [])
+        ]

--- a/dbt/include/athena/macros/adapters/columns.sql
+++ b/dbt/include/athena/macros/adapters/columns.sql
@@ -1,22 +1,3 @@
 {% macro athena__get_columns_in_relation(relation) -%}
-  {% call statement('get_columns_in_relation', fetch_result=True) %}
-
-      select
-          column_name,
-          data_type,
-          null as character_maximum_length,
-          null as numeric_precision,
-          null as numeric_scale
-
-      from {{ relation.information_schema('columns') }}
-      where table_name = LOWER('{{ relation.identifier }}')
-        {% if relation.schema %}
-            and table_schema = LOWER('{{ relation.schema }}')
-        {% endif %}
-      order by ordinal_position
-
-  {% endcall %}
-
-  {% set table = load_result('get_columns_in_relation').table %}
-  {% do return(sql_convert_columns_in_relation(table)) %}
+  {{ return(adapter.get_columns_in_relation(relation)) }}
 {% endmacro %}

--- a/dbt/include/athena/macros/adapters/metadata.sql
+++ b/dbt/include/athena/macros/adapters/metadata.sql
@@ -1,130 +1,13 @@
 {% macro athena__get_catalog(information_schema, schemas) -%}
-    {%- set query -%}
-        select * from (
-            (
-                with tables as (
-
-                    select
-                        tables.table_catalog as table_database,
-                        tables.table_schema as table_schema,
-                        tables.table_name as table_name,
-
-                        case
-                            when views.table_name is not null
-                                then 'view'
-                            when table_type = 'BASE TABLE'
-                                then 'table'
-                            else table_type
-                        end as table_type,
-
-                        null as table_comment
-
-                    from {{ information_schema }}.tables
-                    left join {{ information_schema }}.views
-                        on tables.table_catalog = views.table_catalog
-                        and tables.table_schema = views.table_schema
-                        and tables.table_name = views.table_name
-
-                ),
-
-                columns as (
-
-                    select
-                        table_catalog as table_database,
-                        table_schema as table_schema,
-                        table_name as table_name,
-                        column_name as column_name,
-                        ordinal_position as column_index,
-                        data_type as column_type,
-                        comment as column_comment
-
-                    from {{ information_schema }}.columns
-
-                ),
-
-                catalog as (
-
-                    select
-                        tables.table_database,
-                        tables.table_schema,
-                        tables.table_name,
-                        tables.table_type,
-                        tables.table_comment,
-                        columns.column_name,
-                        columns.column_index,
-                        columns.column_type,
-                        columns.column_comment
-
-                    from tables
-                    join columns
-                        on tables."table_database" = columns."table_database"
-                        and tables."table_schema" = columns."table_schema"
-                        and tables."table_name" = columns."table_name"
-
-                )
-
-                {%- for schema, relations in schemas.items() -%}
-                  {%- for relation_batch in relations|batch(100) %}
-                    select * from catalog
-                    where "table_schema" = lower('{{ schema }}')
-                      and (
-                        {%- for relation in relation_batch -%}
-                          "table_name" = lower('{{ relation }}')
-                        {%- if not loop.last %} or {% endif -%}
-                        {%- endfor -%}
-                      )
-
-                    {%- if not loop.last %} union all {% endif -%}
-                  {%- endfor -%}
-
-                  {%- if not loop.last %} union all {% endif -%}
-                {%- endfor -%}
-            )
-        )
-  {%- endset -%}
-
-  {{ return(run_query(query)) }}
-
+    {{ return(adapter.get_catalog()) }}
 {%- endmacro %}
 
 
 {% macro athena__list_schemas(database) -%}
-  {% call statement('list_schemas', fetch_result=True) %}
-    select
-        distinct schema_name
-
-    from {{ information_schema_name(database) }}.schemata
-  {% endcall %}
-  {{ return(load_result('list_schemas').table) }}
+  {{ return(adapter.list_schemas()) }}
 {% endmacro %}
 
 
 {% macro athena__list_relations_without_caching(schema_relation) %}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    WITH views AS (
-      select
-        table_catalog as database,
-        table_name as name,
-        table_schema as schema
-      from {{ schema_relation.information_schema() }}.views
-      where table_schema = LOWER('{{ schema_relation.schema }}')
-    ), tables AS (
-      select
-        table_catalog as database,
-        table_name as name,
-        table_schema as schema
-
-      from {{ schema_relation.information_schema() }}.tables
-      where table_schema = LOWER('{{ schema_relation.schema }}')
-
-      -- Views appear in both `tables` and `views`, so excluding them from tables
-      EXCEPT
-
-      select * from views
-    )
-    select views.*, 'view' AS table_type FROM views
-    UNION ALL
-    select tables.*, 'table' AS table_type FROM tables
-  {% endcall %}
-  {% do return(load_result('list_relations_without_caching').table) %}
+  {{ return(adapter.list_relations_without_caching(schema_relation)) }}
 {% endmacro %}

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -136,9 +136,9 @@ class MockAWSService:
         athena = boto3.client("athena", region_name=AWS_REGION)
         athena.create_data_catalog(Name=catalog_name, Type=catalog_type, Parameters={"catalog-id": CATALOG_ID})
 
-    def create_database(self):
+    def create_database(self, name: str = DATABASE_NAME):
         glue = boto3.client("glue", region_name=AWS_REGION)
-        glue.create_database(DatabaseInput={"Name": DATABASE_NAME}, CatalogId=CATALOG_ID)
+        glue.create_database(DatabaseInput={"Name": name}, CatalogId=CATALOG_ID)
 
     def create_view(self, view_name: str):
         glue = boto3.client("glue", region_name=AWS_REGION)
@@ -167,10 +167,10 @@ class MockAWSService:
             },
         )
 
-    def create_table(self, table_name: str):
+    def create_table(self, table_name: str, database_name: str = DATABASE_NAME):
         glue = boto3.client("glue", region_name=AWS_REGION)
         glue.create_table(
-            DatabaseName=DATABASE_NAME,
+            DatabaseName=database_name,
             TableInput={
                 "Name": table_name,
                 "StorageDescriptor": {
@@ -182,10 +182,6 @@ class MockAWSService:
                         {
                             "Name": "country",
                             "Type": "string",
-                        },
-                        {
-                            "Name": "dt",
-                            "Type": "date",
                         },
                     ],
                     "Location": f"s3://{BUCKET}/tables/{table_name}",


### PR DESCRIPTION
### Description
Use Glue API instead of Athena information_schema to get info about tables and columns.

## Models used to test - Optional
[These](https://github.com/dbt-athena/dbt-athena-development/pull/2) models

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
