### PR TITLE
fix: Ignore iceberg columns that are not current

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -634,14 +634,11 @@ class AthenaAdapter(SQLAdapter):
     @staticmethod
     def _is_current_column(col: dict) -> bool:
         """
-        Check if a column is current, it always fallback to True if the parameter is not property is not available
+        Check if a column is explicit set as not current. If not, it is considered as current.
         """
-        if col.get("Parameters", {}).get("iceberg.field.current") == "true":
-            return True
-        elif col.get("Parameters", {}).get("iceberg.field.current") == "false":
+        if col.get("Parameters", {}).get("iceberg.field.current") == "false":
             return False
-        else:
-            return True
+        return True
 
     @available
     def get_columns_in_relation(self, relation: AthenaRelation) -> List[Column]:
@@ -653,7 +650,7 @@ class AthenaAdapter(SQLAdapter):
 
         table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.identifier)["Table"]
 
-        columns = [c for c in table["StorageDescriptor"]["Columns"] if self._is_current_column(c) is True]
+        columns = [c for c in table["StorageDescriptor"]["Columns"] if self._is_current_column(c)]
         partition_keys = table.get("PartitionKeys", [])
 
         logger.debug(f"Columns in relation {relation.identifier}: {columns + partition_keys}")

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -656,4 +656,6 @@ class AthenaAdapter(SQLAdapter):
         columns = [c for c in table["StorageDescriptor"]["Columns"] if self._is_current_column(c) is True]
         partition_keys = table.get("PartitionKeys", [])
 
+        logger.debug(f"Columns in relation {relation.identifier}: {columns + partition_keys}")
+
         return [Column(c["Name"], c["Type"]) for c in columns + partition_keys]

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -867,6 +867,17 @@ class TestAthenaAdapter:
     def test_lf_tags_columns_is_valid(self, lf_tags_columns, expected):
         assert self.adapter.lf_tags_columns_is_valid(lf_tags_columns) == expected
 
+    @pytest.mark.parametrize(
+        "column,expected",
+        [
+            pytest.param({"Name": "user_id", "Type": "int", "Parameters": {"iceberg.field.current": "true"}}, True),
+            pytest.param({"Name": "user_id", "Type": "int", "Parameters": {"iceberg.field.current": "false"}}, False),
+            pytest.param({"Name": "user_id", "Type": "int"}, True),
+        ],
+    )
+    def test___is_current_column(self, column, expected):
+        assert self.adapter._is_current_column(column) == expected
+
 
 class TestAthenaFilterCatalog:
     def test__catalog_filter_table(self):

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -875,7 +875,7 @@ class TestAthenaAdapter:
             pytest.param({"Name": "user_id", "Type": "int"}, True),
         ],
     )
-    def test___is_current_column(self, column, expected):
+    def test__is_current_column(self, column, expected):
         assert self.adapter._is_current_column(column) == expected
 
 


### PR DESCRIPTION
### Description
Iceberg support schema evolution, therefore columns can be dropped and added.
If we drop a column the column is somehow returned by the glue api, but it has an atrribute that can be used to pick only current columns. 
This PR aim to fix this issue.


## Models used to test - Optional

### Iceberg append

model: iceberg_testing

```
{{ config(
  materialized='incremental',
  incremental_strategy='append',
  table_type='iceberg',
) }}

SELECT
   'example'  as name,
   1 as user_id,
  cast(replace(cast(at_timezone(current_timestamp, 'Europe/Berlin') as varchar), ' Europe/Berlin', '') as timestamp(6)) as inserted_at
```

* then go run this `ALTER TABLE iceberg_testing DROP COLUMN inserted_at`
* then run the new model removing inserted_at

```
{{ config(
  materialized='incremental',
  incremental_strategy='append',
  table_type='iceberg',
) }}

SELECT
   'example'  as name,
   1 as user_id
```
The model should run because inserted_at=`'iceberg.field.current'='false'` and the field is excluded from the insert statement.


### Iceberg merge

model: iceberg_testing

```
{{ config(
  materialized='incremental',
  incremental_strategy='merge',
  table_type='iceberg',
) }}

SELECT
   'example'  as name,
   1 as user_id,
  cast(replace(cast(at_timezone(current_timestamp, 'Europe/Berlin') as varchar), ' Europe/Berlin', '') as timestamp(6)) as inserted_at
```

* then go run this `ALTER TABLE iceberg_testing DROP COLUMN inserted_at`
* then run the new model removing inserted_at

```
{{ config(
  materialized='incremental',
  incremental_strategy='merge',
  table_type='iceberg',
) }}

SELECT
   'example_2'  as name,
   2 as user_id
```
The model should run because inserted_at=`'iceberg.field.current'='false'` and the field is excluded from the insert statement.



## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [ ] You added functional testing when necessary
