### PR TITLE
remove double quote in vacuum cmd

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -215,6 +215,8 @@ class AthenaParameterFormatter(Formatter):
 
         if operation.upper().startswith(("SELECT", "WITH", "INSERT")):
             escaper = _escape_presto
+        elif operation.upper().startswith("VACUUM"):
+            operation = operation.replace('"', "")
         else:
             # Fixes ParseException that comes with newer version of PyAthena
             operation = operation.replace("\n\n    ", "\n")


### PR DESCRIPTION
### Description

The current "vacuum" command that for Iceberg Table doesn't like the double quote around database name, table name.
For example, this will fail.
```
vacuum "default"."iceberg_table"
```
There is a way to unquote it in DBT by setting `quoting` in project level.
The project level is too broad.

Until AWS Athena resolve the syntax, the workaround can be removing the default double-quoting if the operation starts with "VACUUM"

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [-] You added unit testing when necessary
- [-] You added functional testing when necessary
