### PR TITLE
fix: check for empty workgroup in profiles

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -147,13 +147,14 @@ class AthenaAdapter(SQLAdapter):
         with boto3_client_lock:
             athena_client = client.session.client("athena", region_name=client.region_name, config=get_boto3_config())
 
-        work_group = athena_client.get_work_group(WorkGroup=creds.work_group)
-        return (
-            work_group.get("WorkGroup", {})
-            .get("Configuration", {})
-            .get("ResultConfiguration", {})
-            .get("OutputLocation")
-        )
+        if creds.work_group:
+            work_group = athena_client.get_work_group(WorkGroup=creds.work_group)
+            return (
+                work_group.get("WorkGroup", {})
+                .get("Configuration", {})
+                .get("ResultConfiguration", {})
+                .get("OutputLocation")
+            )
 
     @available
     def s3_table_prefix(self, s3_data_dir: Optional[str]) -> str:


### PR DESCRIPTION
### Description

This fix prevent to fetch the "workgroup" location, if no workgroup is set in the profiles.
If so, `get_work_group_output_location` returns None, and the "location" of the workgroup won't be used.


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
