### PR TITLE
fix: glue column types

### DIFF
--- a/dbt/adapters/athena/column.py
+++ b/dbt/adapters/athena/column.py
@@ -6,7 +6,7 @@ from dbt.exceptions import DbtRuntimeError
 
 @dataclass
 class AthenaColumn(Column):
-    is_iceberg: bool = True
+    is_iceberg: bool = False
 
     def is_string(self) -> bool:
         return self.dtype.lower() in {"varchar", "string"}
@@ -27,13 +27,14 @@ class AthenaColumn(Column):
 
     @classmethod
     def timestamp_type(cls, is_iceberg: bool) -> str:
+        # Iceberg does not support timestamp with precision 3, that's why use timestamp(6)
         return "timestamp(6)" if is_iceberg else "timestamp"
 
     def string_size(self) -> int:
         if not self.is_string():
             raise DbtRuntimeError("Called string_size() on non-string field!")
         if not self.char_size:
-            # Handle error '>' not supported between instances of 'NoneType' and 'NoneType' for union relations macro
+            # Handle error: '>' not supported between instances of 'NoneType' and 'NoneType' for union relations macro
             return 0
         return self.char_size
 

--- a/dbt/adapters/athena/column.py
+++ b/dbt/adapters/athena/column.py
@@ -51,5 +51,5 @@ class AthenaColumn(Column):
         elif self.is_binary():
             return self.binary_type()
         elif self.is_timestamp():
-            return self.timestamp_type(self.table_type)
+            return self.timestamp_type()
         return self.dtype

--- a/dbt/adapters/athena/column.py
+++ b/dbt/adapters/athena/column.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from dbt.adapters.base.column import Column
+from dbt.exceptions import DbtRuntimeError
+
+
+@dataclass
+class AthenaColumn(Column):
+    is_iceberg: bool = True
+
+    def is_string(self) -> bool:
+        return self.dtype.lower() in {"varchar", "string"}
+
+    def is_binary(self) -> bool:
+        return self.dtype.lower() in {"binary", "varbinary"}
+
+    def is_timestamp(self) -> bool:
+        return self.dtype.lower() in {"timestamp"}
+
+    @classmethod
+    def string_type(cls, size: int) -> str:
+        return f"varchar({size})" if size > 0 else "varchar"
+
+    @classmethod
+    def binary_type(cls) -> str:
+        return "varbinary"
+
+    @classmethod
+    def timestamp_type(cls, is_iceberg: bool) -> str:
+        return "timestamp(6)" if is_iceberg else "timestamp"
+
+    def string_size(self) -> int:
+        if not self.is_string():
+            raise DbtRuntimeError("Called string_size() on non-string field!")
+        if not self.char_size:
+            # Handle error '>' not supported between instances of 'NoneType' and 'NoneType' for union relations macro
+            return 0
+        return self.char_size
+
+    @property
+    def data_type(self) -> str:
+        if self.is_string():
+            return self.string_type(self.string_size())
+        elif self.is_numeric():
+            return self.numeric_type(self.dtype, self.numeric_precision, self.numeric_scale)
+        elif self.is_binary():
+            return self.binary_type()
+        elif self.is_timestamp():
+            return self.timestamp_type(self.is_iceberg)
+        return self.dtype

--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -1,7 +1,16 @@
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Dict, Optional, Set
 
 from dbt.adapters.base.relation import BaseRelation, InformationSchema, Policy
+
+
+class TableType(Enum):
+    TABLE = "table"
+    VIEW = "view"
+    CTE = "cte"
+    MATERIALIZED_VIEW = "materializedview"
+    ICEBERG = "iceberg_table"
 
 
 @dataclass


### PR DESCRIPTION
### Description

I'm trying to use `dbt_utils.union_relations` macro, but I get the following error:
TYPE_MISMATCH: line 11:6: Unknown type: string

Same error for types binary and timestamp.

The `AthenaColumn` class is implemented which resolves the problem with col.data_type attribute.

## Models used to test - Optional
I've created 2 source models:
```
create table "sandbox"."tbl1"
  with (
    table_type='iceberg',
    is_external=false,
    location='s3://<bucket_name>/dbt/sandbox/tbl1',
    format='parquet'
  )
  as
select 
localtimestamp(6) as ts,
'abc' as txt,
cast(12.23 as decimal(18,2)) as dcml,
from_hex('34c5b859b4764c0da59cca7675a74fbe') as bnr
```

```
create table "sandbox"."tbl2"
  with (
    table_type='iceberg',
    is_external=false,
    location='s3://<bucket_name>/dbt/sandbox/tbl2',
    format='parquet'
  )
  as
select 
localtimestamp(6) as ts,
'abc' as txt,
cast(12.23 as decimal(18,2)) as dcml,
from_hex('34c5b859b4764c0da59cca7675a74fbe') as bnr
```

also there is sources config:
```
---
version: 2

sources:
  - name: tbl
    schema: sandbox
    tables:
      - name: tbl1
      - name: tbl2

```

and finally the dbt model is 
```
{{
    config(
        materialized='table',
        table_type='iceberg',
        schema='sandbox'
    )
}}

{{ dbt_utils.union_relations(
        [
            source('tbl', 'tbl1'),
            source('tbl', 'tbl2'),
        ],
    )
}}

```

This model runs correctly with updated class but fails with mentioned issues without fixes.

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
