### PR TITLE
fix: return empty if table does not exist in get_columns

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -681,7 +681,15 @@ class AthenaAdapter(SQLAdapter):
         with boto3_client_lock:
             glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
 
-        table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.identifier)["Table"]
+        try:
+            table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.identifier)["Table"]
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "EntityNotFoundException":
+                logger.debug("table not exist, catching the error")
+                return []
+            else:
+                logger.error(e)
+                raise e
 
         columns = [c for c in table["StorageDescriptor"]["Columns"] if self._is_current_column(c)]
         partition_keys = table.get("PartitionKeys", [])

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -848,6 +848,21 @@ class TestAthenaAdapter:
             Column("dt", "date"),
         ]
 
+    @mock_athena
+    @mock_glue
+    def test_get_columns_in_relation_not_found_table(self):
+        self.mock_aws_service.create_data_catalog()
+        self.mock_aws_service.create_database()
+        self.adapter.acquire_connection("dummy")
+        columns = self.adapter.get_columns_in_relation(
+            self.adapter.Relation.create(
+                database=DATA_CATALOG_NAME,
+                schema=DATABASE_NAME,
+                identifier="tbl_name",
+            )
+        )
+        assert columns == []
+
     @pytest.mark.parametrize(
         "response,database,table,columns,lf_tags,expected",
         [


### PR DESCRIPTION
fixes #195

### Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [X] You added unit testing when necessary
- [X] You added functional testing when necessary
