### PR TITLE
fix: reading README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_namespace_packages, setup
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(this_directory, "README.md")) as f:
+with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 package_name = "dbt-athena-community"


### PR DESCRIPTION
Fixing this charcode error

### Description

Tried to build the main branch but got:

```
Updating dependencies
Resolving dependencies...

Unable to determine package info for path: D:\repos\tqa_dbt_models\.venv\src\dbt-athena

Fallback egg_info generation failed.

Command ['.venv\\Scripts\\python.exe', 'setup.py', 'egg_info'] errored with the following return code 1

Output:
Traceback (most recent call last):
  File ".venv\src\dbt-athena\setup.py", line 10, in <module>
    long_description = f.read()
                       ^^^^^^^^
  File "...AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 17701: character maps to <undefined>
```

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [] You added unit testing when necessary
- [x] You added functional testing when necessary
