### PR TITLE
fix: Iceberg CTAS failed when WG config is enforced

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -48,7 +48,7 @@
   with (
     table_type='{{ table_type }}',
     is_external={%- if table_type == 'iceberg' -%}false{%- else -%}true{%- endif %},
-  {%- if not work_group_output_location_enforced -%}
+  {%- if not work_group_output_location_enforced or table_type == 'iceberg' -%}
     {{ location_property }}='{{ location }}',
   {%- endif %}
   {%- if partitioned_by is not none %}


### PR DESCRIPTION
### Description

Iceberg CTAS failed when `location` is not set although the used WorkGroup enables "Override client side settings".
Using and forcing the query result path of WorkGroup works only if Table Type is Hive.

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
