### PR TITLE
fix: use table as default type when building the catalog

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -377,7 +377,7 @@ class AthenaAdapter(SQLAdapter):
             "table_database": database,
             "table_schema": table["DatabaseName"],
             "table_name": table["Name"],
-            "table_type": self.relation_type_map[table.get("TableType", "table")].value,
+            "table_type": self.relation_type_map[table.get("TableType", "EXTERNAL_TABLE")].value,
             "table_comment": table.get("Parameters", {}).get("comment", table.get("Description", "")),
         }
         return [

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -377,7 +377,7 @@ class AthenaAdapter(SQLAdapter):
             "table_database": database,
             "table_schema": table["DatabaseName"],
             "table_name": table["Name"],
-            "table_type": self.relation_type_map[table["TableType"]].value,
+            "table_type": self.relation_type_map[table.get("TableType", "table")].value,
             "table_comment": table.get("Parameters", {}).get("comment", table.get("Description", "")),
         }
         return [

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -202,6 +202,34 @@ class MockAWSService:
             },
         )
 
+    def create_table_without_type(self, table_name: str, database_name: str = DATABASE_NAME):
+        glue = boto3.client("glue", region_name=AWS_REGION)
+        glue.create_table(
+            DatabaseName=database_name,
+            TableInput={
+                "Name": table_name,
+                "StorageDescriptor": {
+                    "Columns": [
+                        {
+                            "Name": "id",
+                            "Type": "string",
+                        },
+                        {
+                            "Name": "country",
+                            "Type": "string",
+                        },
+                    ],
+                    "Location": f"s3://{BUCKET}/tables/{table_name}",
+                },
+                "Parameters": {
+                    "compressionType": "snappy",
+                    "classification": "parquet",
+                    "projection.enabled": "false",
+                    "typeOfData": "file",
+                },
+            },
+        )
+
     def create_table_without_partitions(self, table_name: str):
         glue = boto3.client("glue", region_name=AWS_REGION)
         glue.create_table(


### PR DESCRIPTION
### Description

This address this issue: https://github.com/dbt-athena/dbt-athena/issues/240
There are some edge cases when tables are created by api, where table type is not set, this pr uses a fallback to table in those cases, as it's the best assumption.


## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
