### PR TITLE
fix: use identifier for seed tables

### DIFF
--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -53,7 +53,7 @@
 
   -- create tmp relation
   {%- set tmp_relation = api.Relation.create(
-    identifier=model.name + "__dbt_tmp",
+    identifier=identifier + "__dbt_tmp",
     schema=model.schema,
     database=model.database,
     type='table'
@@ -61,7 +61,7 @@
 
   -- create target relation
   {%- set relation = api.Relation.create(
-    identifier=model.name,
+    identifier=identifier,
     schema=model.schema,
     database=model.database,
     type='table'


### PR DESCRIPTION
### Description
Issue: When using the macro `generate_alias_name` the table created by the seed does not use the alias but the model name, leading to a wrong table name.

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
