### PR TITLE
feat: add iceberg high availability on table using rename

### DIFF
--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -24,6 +24,7 @@ class AthenaIncludePolicy(Policy):
 class AthenaRelation(BaseRelation):
     quote_character: str = '"'  # Presto quote character
     include_policy: Policy = field(default_factory=lambda: AthenaIncludePolicy())
+    s3_path_table_part: Optional[str] = None
 
     def render_hive(self):
         """

--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -20,3 +20,9 @@
     alter table {{ relation.render_hive() }} set tblproperties ('classification' = '{{ format }}')
   {%- endcall %}
 {%- endmacro %}
+
+{% macro athena__rename_relation(from_relation, to_relation) %}
+  {% call statement('rename_relation') -%}
+    alter table {{ from_relation.render_hive() }} rename to `{{ to_relation.schema }}`.`{{ to_relation.identifier }}`
+  {%- endcall %}
+{%- endmacro %}

--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -15,7 +15,13 @@
   {%- set location_property = 'external_location' -%}
   {%- set partition_property = 'partitioned_by' -%}
   {%- set work_group_output_location_enforced = adapter.is_work_group_output_location_enforced() -%}
-  {%- set location = adapter.s3_table_location(s3_data_dir, s3_data_naming, relation.schema, relation.identifier, external_location, temporary) -%}
+  {%- set location = adapter.s3_table_location(s3_data_dir,
+                                               s3_data_naming,
+                                               relation.schema,
+                                               relation.identifier,
+                                               relation.s3_path_table_part,
+                                               external_location,
+                                               temporary) -%}
 
   {%- if materialized == 'table_hive_ha' -%}
     {%- set location = location.replace('__ha', '') -%}


### PR DESCRIPTION
### Description

This PR resolves #73. I had to add an extra parameter to the `AthenaRelation`, called `s3_path_table_part` to have the table stored in the correct location.

## Models used to test - Optional
```sql
{{ config(
  materialized='table',
  partitioned_by=['hour(ts)'],
  table_type='iceberg',
  table_properties={
    'vacuum_max_snapshot_age_seconds': '86400',
    'optimize_rewrite_delete_file_threshold': '2'
  }
) }}

SELECT cast(t.ts AS timestamp(6)) AS ts
FROM
    unnest(
        sequence(
            current_date - INTERVAL '1' DAY,
            cast(REPLACE(cast(current_timestamp as varchar), ' UTC', '') as timestamp(6)),
            INTERVAL '1' MINUTE
        )
    ) AS t(ts)
```

## Checklist
- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [X] You added unit testing when necessary
- [] You added functional testing when necessary
