### PR TITLE
fix: check for database in _get_one_catalog (#247)

### DIFF
--- a/tests/unit/constants.py
+++ b/tests/unit/constants.py
@@ -1,5 +1,6 @@
 CATALOG_ID = "catalog_id"
 DATA_CATALOG_NAME = "awsdatacatalog"
+SHARED_DATA_CATALOG_NAME = "12345678910"
 DATABASE_NAME = "test_dbt_athena"
 BUCKET = "test-dbt-athena"
 AWS_REGION = "eu-west-1"

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -27,6 +27,7 @@ from .constants import (
     DATA_CATALOG_NAME,
     DATABASE_NAME,
     S3_STAGING_DIR,
+    SHARED_DATA_CATALOG_NAME,
 )
 from .fixtures import seed_data
 from .utils import (
@@ -69,6 +70,7 @@ class TestAthenaAdapter:
             ("awsdatacatalog", "foo"),
             ("awsdatacatalog", "quux"),
             ("awsdatacatalog", "baz"),
+            (SHARED_DATA_CATALOG_NAME, "foo"),
         }
         self.mock_manifest.nodes = {
             "model.root.model1": CompiledNode(
@@ -172,6 +174,42 @@ class TestAthenaAdapter:
                 tags=[],
                 path="model3.sql",
                 original_file_path="model3.sql",
+                compiled=True,
+                extra_ctes_injected=False,
+                extra_ctes=[],
+                checksum=FileHash.from_contents(""),
+                raw_code="select * from source_table",
+                language="",
+            ),
+            "model.root.model4": CompiledNode(
+                name="model4",
+                database="12345678910",
+                schema="foo",
+                resource_type=NodeType.Model,
+                unique_id="model.root.model4",
+                alias="bar",
+                fqn=["root", "model4"],
+                package_name="root",
+                refs=[],
+                sources=[],
+                depends_on=DependsOn(),
+                config=NodeConfig.from_dict(
+                    {
+                        "enabled": True,
+                        "materialized": "table",
+                        "persist_docs": {},
+                        "post-hook": [],
+                        "pre-hook": [],
+                        "vars": {},
+                        "meta": {"owner": "data-engineers"},
+                        "quoting": {},
+                        "column_types": {},
+                        "tags": [],
+                    }
+                ),
+                tags=[],
+                path="model4.sql",
+                original_file_path="model4.sql",
                 compiled=True,
                 extra_ctes_injected=False,
                 extra_ctes=[],
@@ -436,10 +474,12 @@ class TestAthenaAdapter:
         self.mock_aws_service.create_table(table_name="bar", database_name="foo")
         self.mock_aws_service.create_table(table_name="bar", database_name="quux")
         self.mock_aws_service.create_table_without_type(table_name="qux", database_name="baz")
+        mock_information_schema = mock.MagicMock()
+        mock_information_schema.path.database = "awsdatacatalog"
 
         self.adapter.acquire_connection("dummy")
         actual = self.adapter._get_one_catalog(
-            mock.MagicMock(),
+            mock_information_schema,
             {
                 "foo": {"bar"},
                 "quux": {"bar"},
@@ -476,16 +516,66 @@ class TestAthenaAdapter:
         for row in actual.rows.values():
             assert row.values() in expected_rows
 
+    @mock_glue
+    @mock_athena
+    def test__get_one_catalog_shared_catalog(self):
+        self.mock_aws_service.create_data_catalog(catalog_name=SHARED_DATA_CATALOG_NAME)
+        self.mock_aws_service.create_database("foo")
+        self.mock_aws_service.create_table(table_name="bar", database_name="foo")
+        mock_information_schema = mock.MagicMock()
+        mock_information_schema.path.database = SHARED_DATA_CATALOG_NAME
+
+        self.adapter.acquire_connection("dummy")
+        actual = self.adapter._get_one_catalog(
+            mock_information_schema,
+            {
+                "foo": {"bar"},
+            },
+            self.mock_manifest,
+        )
+
+        expected_column_names = (
+            "table_database",
+            "table_schema",
+            "table_name",
+            "table_type",
+            "table_comment",
+            "column_name",
+            "column_index",
+            "column_type",
+            "column_comment",
+            "table_owner",
+        )
+        expected_rows = [
+            ("12345678910", "foo", "bar", "table", None, "id", 0, "string", None, "data-engineers"),
+            ("12345678910", "foo", "bar", "table", None, "country", 1, "string", None, "data-engineers"),
+            ("12345678910", "foo", "bar", "table", None, "dt", 2, "date", None, "data-engineers"),
+        ]
+
+        assert actual.column_names == expected_column_names
+        assert len(actual.rows) == len(expected_rows)
+        for row in actual.rows.values():
+            assert row.values() in expected_rows
+
     def test__get_catalog_schemas(self):
         res = self.adapter._get_catalog_schemas(self.mock_manifest)
-        assert len(res.keys()) == 1
-        information_schema = list(res.keys())[0]
-        assert information_schema.name == "INFORMATION_SCHEMA"
-        assert information_schema.schema is None
-        assert information_schema.database == "awsdatacatalog"
+        assert len(res.keys()) == 2
+
+        information_schema_0 = list(res.keys())[0]
+        assert information_schema_0.name == "INFORMATION_SCHEMA"
+        assert information_schema_0.schema is None
+        assert information_schema_0.database == "awsdatacatalog"
         relations = list(res.values())[0]
         assert set(relations.keys()) == {"foo", "quux", "baz"}
         assert list(relations.values()) == [{"bar"}, {"bar"}, {"qux"}]
+
+        information_schema_1 = list(res.keys())[1]
+        assert information_schema_1.name == "INFORMATION_SCHEMA"
+        assert information_schema_1.schema is None
+        assert information_schema_1.database == SHARED_DATA_CATALOG_NAME
+        relations = list(res.values())[1]
+        assert set(relations.keys()) == {"foo"}
+        assert list(relations.values()) == [{"bar"}]
 
     @mock_athena
     def test__get_data_catalog(self, aws_credentials):


### PR DESCRIPTION
### Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

Resolves #247. 

The adapter method `_get_one_catalog` didn't account for the schema database when it was passed in the `schema.yml` file. Now if catalog_id is not `awsdatacatalog`, `_get_one_catalog` will get the catalog_id/database from the information_schema.

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [ ] You added functional testing when necessary
