### PR TITLE
feat: AWS LakeFormation data cell filters support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,32 @@ _Additional information_
       tag1:
         value1: [ column1, column2 ]
 ```
+* `lf_grants` (`default=none`)
+  * lakeformation grants config for data_cell filters
+  * format:
+  ```python
+  lf_grants={
+          'data_cell_filters': {
+              'enabled': True | False,
+              'filters': {
+                  'filter_name': {
+                      'row_filter': '<filter_condition>',
+                      'principals': ['principal_arn1', 'principal_arn2']
+                  }
+              }
+          }
+      }
+  ```
+
+> Notes:  
+> - `lf_tags` and `lf_tags_columns` configs support only attaching lf tags to corresponding resources.
+> We recommend managing LF Tags permissions somewhere outside dbt. For example, you may use
+> [terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_permissions) or
+> [aws cdk](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-lakeformation-readme.html) for such purpose.
+> - `data_cell_filters` management can't be automated outside dbt because the filter can't be attached to the table
+> which doesn't exist. Once you `enable` this config, dbt will set all filters and their permissions during every
+> dbt run. Such approach keeps the actual state of row level security configuration actual after every dbt run and
+> apply changes if they occur: drop, create, update filters and their permissions.
 
 [create-table-as]: https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html#ctas-table-properties
 

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -21,7 +21,12 @@ from dbt.adapters.athena.exceptions import (
     S3LocationException,
     SnapshotMigrationRequired,
 )
-from dbt.adapters.athena.lakeformation import LfTagsConfig, LfTagsManager, LfGrantsConfig, LfPermissions
+from dbt.adapters.athena.lakeformation import (
+    LfGrantsConfig,
+    LfPermissions,
+    LfTagsConfig,
+    LfTagsManager,
+)
 from dbt.adapters.athena.relation import (
     RELATION_TYPE_MAP,
     AthenaRelation,

--- a/dbt/adapters/athena/lakeformation.py
+++ b/dbt/adapters/athena/lakeformation.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Optional, Union
 from mypy_boto3_lakeformation import LakeFormationClient
 from mypy_boto3_lakeformation.type_defs import (
     AddLFTagsToResourceResponseTypeDef,
+    BatchPermissionsRequestEntryTypeDef,
+    DataCellsFilterTypeDef,
     GetResourceLFTagsResponseTypeDef,
     RemoveLFTagsFromResourceResponseTypeDef,
     ResourceTypeDef,
@@ -116,6 +118,8 @@ class LfTagsManager:
                 logger.error(f"Failed to {verb} {tag} for {self.database}.{self.table}" + f" - {error}")
             raise DbtRuntimeError(base_msg)
         return f"Success: {verb} LF tags: {lf_tags} to {self.database}.{self.table}" + columns_appendix
+
+
 class FilterConfig(BaseModel):
     row_filter: str
     column_names: List[str] = []

--- a/dbt/adapters/athena/lakeformation.py
+++ b/dbt/adapters/athena/lakeformation.py
@@ -1,3 +1,5 @@
+"""AWS Lakeformation permissions management helper utilities."""
+
 from typing import Dict, List, Optional, Union
 
 from mypy_boto3_lakeformation import LakeFormationClient
@@ -114,3 +116,133 @@ class LfTagsManager:
                 logger.error(f"Failed to {verb} {tag} for {self.database}.{self.table}" + f" - {error}")
             raise DbtRuntimeError(base_msg)
         return f"Success: {verb} LF tags: {lf_tags} to {self.database}.{self.table}" + columns_appendix
+class FilterConfig(BaseModel):
+    row_filter: str
+    column_names: List[str] = []
+    principals: List[str] = []
+
+    def to_api_repr(self, catalog_id: str, database: str, table: str, name: str) -> DataCellsFilterTypeDef:
+        return {
+            "TableCatalogId": catalog_id,
+            "DatabaseName": database,
+            "TableName": table,
+            "Name": name,
+            "RowFilter": {"FilterExpression": self.row_filter},
+            "ColumnNames": self.column_names,
+            "ColumnWildcard": {"ExcludedColumnNames": []},
+        }
+
+    def to_update(self, existing: DataCellsFilterTypeDef) -> bool:
+        return self.row_filter != existing["RowFilter"]["FilterExpression"] or set(self.column_names) != set(
+            existing["ColumnNames"]
+        )
+
+
+class DataCellFiltersConfig(BaseModel):
+    enabled: bool = False
+    filters: Dict[str, FilterConfig]
+
+
+class LfGrantsConfig(BaseModel):
+    data_cell_filters: DataCellFiltersConfig
+
+
+class LfPermissions:
+    def __init__(self, catalog_id: str, relation: AthenaRelation, lf_client: LakeFormationClient) -> None:
+        self.catalog_id = catalog_id
+        self.relation = relation
+        self.database: str = relation.schema
+        self.table: str = relation.identifier
+        self.lf_client = lf_client
+
+    def get_filters(self) -> Dict[str, DataCellsFilterTypeDef]:
+        table_resource = {"CatalogId": self.catalog_id, "DatabaseName": self.database, "Name": self.table}
+        return {f["Name"]: f for f in self.lf_client.list_data_cells_filter(Table=table_resource)["DataCellsFilters"]}
+
+    def process_filters(self, config: LfGrantsConfig) -> None:
+        current_filters = self.get_filters()
+        logger.debug(f"CURRENT FILTERS: {current_filters}")
+
+        to_drop = [f for name, f in current_filters.items() if name not in config.data_cell_filters.filters]
+        logger.debug(f"FILTERS TO DROP: {to_drop}")
+        for f in to_drop:
+            self.lf_client.delete_data_cells_filter(
+                TableCatalogId=f["TableCatalogId"],
+                DatabaseName=f["DatabaseName"],
+                TableName=f["TableName"],
+                Name=f["Name"],
+            )
+
+        to_add = [
+            f.to_api_repr(self.catalog_id, self.database, self.table, name)
+            for name, f in config.data_cell_filters.filters.items()
+            if name not in current_filters
+        ]
+        logger.debug(f"FILTERS TO ADD: {to_add}")
+        for f in to_add:
+            self.lf_client.create_data_cells_filter(TableData=f)
+
+        to_update = [
+            f.to_api_repr(self.catalog_id, self.database, self.table, name)
+            for name, f in config.data_cell_filters.filters.items()
+            if name in current_filters and f.to_update(current_filters[name])
+        ]
+        logger.debug(f"FILTERS TO UPDATE: {to_update}")
+        for f in to_update:
+            self.lf_client.update_data_cells_filter(TableData=f)
+
+    def process_permissions(self, config: LfGrantsConfig):
+        for name, f in config.data_cell_filters.filters.items():
+            logger.debug(f"Start processing permissions for filter: {name}")
+            current_permissions = self.lf_client.list_permissions(
+                Resource={
+                    "DataCellsFilter": {
+                        "TableCatalogId": self.catalog_id,
+                        "DatabaseName": self.database,
+                        "TableName": self.table,
+                        "Name": name,
+                    }
+                }
+            )["PrincipalResourcePermissions"]
+
+            current_principals = {p["Principal"]["DataLakePrincipalIdentifier"] for p in current_permissions}
+
+            to_revoke = {p for p in current_principals if p not in f.principals}
+            if to_revoke:
+                self.lf_client.batch_revoke_permissions(
+                    CatalogId=self.catalog_id,
+                    Entries=[self._permission_entry(name, principal, idx) for idx, principal in enumerate(to_revoke)],
+                )
+                revoke_principals_msg = "\n".join(to_revoke)
+                logger.debug(f"Revoked permissions for filter {name} from principals:\n{revoke_principals_msg}")
+            else:
+                logger.debug(f"No redundant permissions found for filter: {name}")
+
+            to_add = {p for p in f.principals if p not in current_principals}
+            if to_add:
+                self.lf_client.batch_grant_permissions(
+                    CatalogId=self.catalog_id,
+                    Entries=[self._permission_entry(name, principal, idx) for idx, principal in enumerate(to_add)],
+                )
+                add_principals_msg = "\n".join(to_add)
+                logger.debug(f"Granted permissions for filter {name} to principals:\n{add_principals_msg}")
+            else:
+                logger.debug(f"No new permissions added for filter {name}")
+
+            logger.debug(f"Permissions are set to be consistent with config for filter: {name}")
+
+    def _permission_entry(self, filter_name: str, principal: str, idx: int) -> BatchPermissionsRequestEntryTypeDef:
+        return {
+            "Id": str(idx),
+            "Principal": {"DataLakePrincipalIdentifier": principal},
+            "Resource": {
+                "DataCellsFilter": {
+                    "TableCatalogId": self.catalog_id,
+                    "DatabaseName": self.database,
+                    "TableName": self.table,
+                    "Name": filter_name,
+                }
+            },
+            "Permissions": ["SELECT"],
+            "PermissionsWithGrantOption": [],
+        }

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -5,8 +5,8 @@
   {% set strategy = validate_get_incremental_strategy(raw_strategy, table_type) %}
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
 
-  {% set lf_tags_config = config.get('lf_tags_config', default=none) %}
-  {% set lf_grants = config.get('lf_grants', default=none) %}
+  {% set lf_tags_config = config.get('lf_tags_config') %}
+  {% set lf_grants = config.get('lf_grants') %}
   {% set partitioned_by = config.get('partitioned_by', default=none) %}
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -6,6 +6,7 @@
   {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
 
   {% set lf_tags_config = config.get('lf_tags_config', default=none) %}
+  {% set lf_grants = config.get('lf_grants', default=none) %}
   {% set partitioned_by = config.get('partitioned_by', default=none) %}
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
@@ -85,6 +86,10 @@
 
   {% if lf_tags_config is not none %}
     {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
+  {% endif %}
+
+  {% if lf_grants is not none %}
+    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -2,8 +2,9 @@
 {% materialization table, adapter='athena' -%}
   {%- set identifier = model['alias'] -%}
 
-  {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
-  {%- set lf_grants = config.get('lf_grants', default=none) -%}
+  {%- set lf_tags_config = config.get('lf_tags_config') -%}
+  {%- set lf_grants = config.get('lf_grants') -%}
+
   {%- set table_type = config.get('table_type', default='hive') | lower -%}
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set is_ha = config.get('ha', default=false) -%}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -3,6 +3,7 @@
   {%- set identifier = model['alias'] -%}
 
   {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
+  {%- set lf_grants = config.get('lf_grants', default=none) -%}
   {%- set table_type = config.get('table_type', default='hive') | lower -%}
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set is_ha = config.get('ha', default=false) -%}
@@ -109,6 +110,10 @@
 
   {% if lf_tags_config is not none %}
     {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
+  {% endif %}
+
+  {% if lf_grants is not none %}
+    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}

--- a/dbt/include/athena/macros/materializations/models/view/create_or_replace_view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/create_or_replace_view.sql
@@ -1,8 +1,9 @@
 {% macro create_or_replace_view(run_outside_transaction_hooks=True) %}
   {%- set identifier = model['alias'] -%}
 
-  {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
-  {%- set lf_grants = config.get('lf_grants', default=none) -%}
+  {%- set lf_tags_config = config.get('lf_tags_config') -%}
+  {%- set lf_grants = config.get('lf_grants') -%}
+
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
   {%- set target_relation = api.Relation.create(

--- a/dbt/include/athena/macros/materializations/models/view/create_or_replace_view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/create_or_replace_view.sql
@@ -2,6 +2,7 @@
   {%- set identifier = model['alias'] -%}
 
   {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
+  {%- set lf_grants = config.get('lf_grants', default=none) -%}
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
   {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
   {%- set target_relation = api.Relation.create(
@@ -31,6 +32,10 @@
 
   {% if lf_tags_config is not none %}
     {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
+  {% endif %}
+
+  {% if lf_grants is not none %}
+    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
   {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -35,6 +35,7 @@
   {%- set identifier = model['alias'] -%}
 
   {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
+  {%- set lf_grants = config.get('lf_grants', default=none) -%}
   {%- set column_override = config.get('column_types', {}) -%}
   {%- set quote_seed_column = config.get('quote_columns', None) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
@@ -120,6 +121,10 @@
 
   {% if lf_tags_config is not none %}
     {{ adapter.add_lf_tags(model, lf_tags_config) }}
+  {% endif %}
+
+  {% if lf_grants is not none %}
+    {{ adapter.apply_lf_grants(relation, lf_grants) }}
   {% endif %}
 
   {{ return(sql_table) }}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -124,7 +124,7 @@
   {% endif %}
 
   {% if lf_grants is not none %}
-    {{ adapter.apply_lf_grants(relation, lf_grants) }}
+    {{ adapter.apply_lf_grants(model, lf_grants) }}
   {% endif %}
 
   {{ return(sql_table) }}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -34,8 +34,9 @@
 {% macro athena__create_csv_table(model, agate_table) %}
   {%- set identifier = model['alias'] -%}
 
-  {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
-  {%- set lf_grants = config.get('lf_grants', default=none) -%}
+  {%- set lf_tags_config = config.get('lf_tags_config') -%}
+  {%- set lf_grants = config.get('lf_grants') -%}
+
   {%- set column_override = config.get('column_types', {}) -%}
   {%- set quote_seed_column = config.get('quote_columns', None) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}

--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -120,11 +120,11 @@
   {% do adapter.delete_from_s3(tmp_s3_location) %}
 
   {% if lf_tags_config is not none %}
-    {{ adapter.add_lf_tags(model, lf_tags_config) }}
+    {{ adapter.add_lf_tags(relation, lf_tags_config) }}
   {% endif %}
 
   {% if lf_grants is not none %}
-    {{ adapter.apply_lf_grants(model, lf_grants) }}
+    {{ adapter.apply_lf_grants(relation, lf_grants) }}
   {% endif %}
 
   {{ return(sql_table) }}

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -123,13 +123,11 @@
   {%- set config = model['config'] -%}
 
   {%- set target_table = model.get('alias', model.get('name')) -%}
-  {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
   {%- set strategy_name = config.get('strategy') -%}
   {%- set file_format = config.get('file_format', 'parquet') -%}
   {%- set table_type = config.get('table_type', 'hive') -%}
 
-  {%- set lf_tags = config.get('lf_tags', default=none) -%}
-  {%- set lf_tags_columns = config.get('lf_tags_columns', default=none) -%}
+  {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
   {%- set lf_grants = config.get('lf_grants', default=none) -%}
 
 
@@ -238,11 +236,11 @@
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {% if lf_tags_config %}
-    {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
+    {{ adapter.add_lf_tags(model, lf_tags_config) }}
   {% endif %}
 
   {% if lf_grants is not none %}
-    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
+    {{ adapter.apply_lf_grants(model, lf_grants) }}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -235,14 +235,10 @@
       {% do adapter.drop_relation(new_snapshot_table) %}
   {% endif %}
 
-  {% if lf_tags_config is not none %}
-    {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
-  {% endif %}
-
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
-  {% if lf_tags is not none or lf_tags_columns is not none %}
-    {{ adapter.add_lf_tags(target_relation.schema, identifier, lf_tags, lf_tags_columns) }}
+  {% if lf_tags_config %}
+    {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
   {% endif %}
 
   {% if lf_grants is not none %}

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -236,11 +236,11 @@
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {% if lf_tags_config %}
-    {{ adapter.add_lf_tags(model, lf_tags_config) }}
+    {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
   {% endif %}
 
   {% if lf_grants is not none %}
-    {{ adapter.apply_lf_grants(model, lf_grants) }}
+    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -127,9 +127,6 @@
   {%- set file_format = config.get('file_format', 'parquet') -%}
   {%- set table_type = config.get('table_type', 'hive') -%}
 
-  {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
-  {%- set lf_grants = config.get('lf_grants', default=none) -%}
-
 
   {{ log('Checking if target table exists') }}
   {% set target_relation_exists, target_relation = get_or_create_relation(
@@ -234,14 +231,6 @@
   {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
-
-  {% if lf_tags_config %}
-    {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
-  {% endif %}
-
-  {% if lf_grants is not none %}
-    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
-  {% endif %}
 
   {% do persist_docs(target_relation, model) %}
 

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -128,6 +128,10 @@
   {%- set file_format = config.get('file_format', 'parquet') -%}
   {%- set table_type = config.get('table_type', 'hive') -%}
 
+  {%- set lf_tags = config.get('lf_tags', default=none) -%}
+  {%- set lf_tags_columns = config.get('lf_tags_columns', default=none) -%}
+  {%- set lf_grants = config.get('lf_grants', default=none) -%}
+
 
   {{ log('Checking if target table exists') }}
   {% set target_relation_exists, target_relation = get_or_create_relation(
@@ -236,6 +240,14 @@
   {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {% if lf_tags is not none or lf_tags_columns is not none %}
+    {{ adapter.add_lf_tags(target_relation.schema, identifier, lf_tags, lf_tags_columns) }}
+  {% endif %}
+
+  {% if lf_grants is not none %}
+    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
+  {% endif %}
 
   {% do persist_docs(target_relation, model) %}
 

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -127,6 +127,8 @@
   {%- set file_format = config.get('file_format', 'parquet') -%}
   {%- set table_type = config.get('table_type', 'hive') -%}
 
+  {%- set lf_tags_config = config.get('lf_tags_config') -%}
+  {%- set lf_grants = config.get('lf_grants') -%}
 
   {{ log('Checking if target table exists') }}
   {% set target_relation_exists, target_relation = get_or_create_relation(
@@ -231,6 +233,14 @@
   {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {% if lf_tags_config %}
+    {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
+  {% endif %}
+
+  {% if lf_grants is not none %}
+    {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
+  {% endif %}
 
   {% do persist_docs(target_relation, model) %}
 

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -234,7 +234,7 @@
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
-  {% if lf_tags_config %}
+  {% if lf_tags_config is not none %}
     {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
   {% endif %}
 

--- a/dbt/include/athena/sample_profiles.yml
+++ b/dbt/include/athena/sample_profiles.yml
@@ -7,9 +7,6 @@ default:
       region_name: [region_name]
       database: [database name]
       schema: [dev_schema]
-      lf_tags:
-        origin: dbt
-        team: analytics
 
     prod:
       type: athena

--- a/tests/functional/adapter/test_snapshot.py
+++ b/tests/functional/adapter/test_snapshot.py
@@ -66,8 +66,11 @@ id,name,some_date
 iceberg_cc_all_snapshot_sql = """
 {% snapshot cc_all_snapshot %}
     {{ config(
-        check_cols='all', unique_key='id', strategy='check',
-        target_database=database, target_schema=schema,
+        check_cols='all',
+        unique_key='id',
+        strategy='check',
+        target_database=database,
+        target_schema=schema,
         table_type='iceberg'
     ) }}
     select
@@ -82,8 +85,11 @@ iceberg_cc_all_snapshot_sql = """
 iceberg_cc_name_snapshot_sql = """
 {% snapshot cc_name_snapshot %}
     {{ config(
-        check_cols=['name'], unique_key='id', strategy='check',
-        target_database=database, target_schema=schema,
+        check_cols=['name'],
+        unique_key='id',
+        strategy='check',
+        target_database=database,
+        target_schema=schema,
         table_type='iceberg'
     ) }}
     select
@@ -98,8 +104,11 @@ iceberg_cc_name_snapshot_sql = """
 iceberg_cc_date_snapshot_sql = """
 {% snapshot cc_date_snapshot %}
     {{ config(
-        check_cols=['some_date'], unique_key='id', strategy='check',
-        target_database=database, target_schema=schema,
+        check_cols=['some_date'],
+        unique_key='id',
+        strategy='check',
+        target_database=database,
+        target_schema=schema,
         table_type='iceberg'
     ) }}
     select


### PR DESCRIPTION
### Description

- `lf_tags` and `lf_tags_columns` configs support only attaching lf tags to corresponding resources.
We recommend managing LF Tags permissions somewhere outside dbt. For example, you may use
[terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lakeformation_permissions) or [aws cdk](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-lakeformation-readme.html) for such purpose.
- `data_cell_filters` management can't be automated outside dbt because the filter can't be attached to the table
which doesn't exist. Once you `enable` this config, dbt will set all filters and their permissions during every
dbt run. Such approach keeps the actual state of row level security configuration actual after every dbt run and
apply changes if they occur: drop, create, update filters and their permissions.

## Model example

```
{{
  config(
    materialized='incremental',
    incremental_strategy='append',
    on_schema_change='append_new_columns',
    table_type='iceberg',
    lf_grants={
        'data_cell_filters': {
            'enabled': True,
            'filters': {
                'test_a': {
                    'row_filter': "rls = 'a'",
                    'principals': ['arn:aws:iam::<account_id>:role/<role_name>']
                },
                'test_b': {
                    'row_filter': "rls = 'b'",
                    'principals': ['arn:aws:iam::<account_id>:role/<role_name>']
                },
                'test_c': {
                    'row_filter': "rls = 'c'",
                    'principals': ['arn:aws:iam::<account_id>:role/<role_name>']
                }
            }
        }
    }
  )
}}

select
    1 as id,
    'a' as rls
union all
select
    2 as id,
    'b' as rls
union all
select
    3 as id,
    'c' as rls

```

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
