### PR TITLE
fix: seed method upload or insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ A dbt profile can be configured to run against AWS Athena using the following co
 | work_group            | Identifier of Athena workgroup                                                 | Optional  | `my-custom-workgroup`                      |
 | num_retries           | Number of times to retry a failing query                                       | Optional  | `3`                                        |
 | lf_tags               | Default lf tags to apply to any database created by dbt                        | Optional  | `{"origin": "dbt", "team": "analytics"}`   |
+| seed_by_insert        | When `True`, create seeds by inserting records, rather than uploading to S3. Does not require s3:PutObject permissions. | Optional  | `False` (default) |
+
 
 **Example profiles.yml entry:**
 ```yaml

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -50,6 +50,7 @@ class AthenaCredentials(Credentials):
     s3_data_dir: Optional[str] = None
     s3_data_naming: Optional[str] = "schema_table_unique"
     lf_tags: Optional[Dict[str, str]] = None
+    seed_by_insert: Optional[bool] = False
 
     @property
     def type(self) -> str:
@@ -74,6 +75,7 @@ class AthenaCredentials(Credentials):
             "s3_data_dir",
             "s3_data_naming",
             "lf_tags",
+            "seed_by_insert",
         )
 
 

--- a/tests/functional/seeds/fixtures.py
+++ b/tests/functional/seeds/fixtures.py
@@ -1,0 +1,24 @@
+# seeds/my_seed.csv
+my_seed_csv = """
+id,name,some_date
+1,Easton,1981-05-20T06:46:51
+2,Lillian,1978-09-03T18:10:33
+3,Jeremiah,1982-03-11T03:59:51
+4,Nolan,1976-05-06T20:21:35
+""".lstrip()
+
+my_seed_yaml = """
+version: 2
+seeds:
+  - name: my_seed
+    columns:
+      - name: name
+        tests:
+          - accepted_values:
+              values: ['nomatch']
+              config:
+                severity: error
+                error_if: "!=4"
+                warn_if: "!=4"
+
+"""

--- a/tests/functional/seeds/test_seed_insert.py
+++ b/tests/functional/seeds/test_seed_insert.py
@@ -16,4 +16,5 @@ class TestSeedByInsert:
         return {"my_seed.csv": my_seed_csv, "my_seed.yaml": my_seed_yaml}
 
     def test_seed(self, project):
+        # not sure how best to check that this actually ended up being an insert vs. an upload...?
         run_dbt(["build"])

--- a/tests/functional/seeds/test_seed_insert.py
+++ b/tests/functional/seeds/test_seed_insert.py
@@ -1,0 +1,19 @@
+import pytest
+from tests.functional.seeds.fixtures import my_seed_csv, my_seed_yaml
+
+from dbt.tests.util import run_dbt
+
+
+class TestSeedByInsert:
+    @pytest.fixture(scope="class")
+    def profiles_config_update(self, dbt_profile_target):
+        return {
+            "test": {"outputs": {"default": {**dbt_profile_target, **{"seed_by_insert": True}}}},
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"my_seed.csv": my_seed_csv, "my_seed.yaml": my_seed_yaml}
+
+    def test_seed(self, project):
+        run_dbt(["build"])

--- a/tests/functional/seeds/test_seed_upload.py
+++ b/tests/functional/seeds/test_seed_upload.py
@@ -1,0 +1,13 @@
+import pytest
+from tests.functional.seeds.fixtures import my_seed_csv, my_seed_yaml
+
+from dbt.tests.util import run_dbt
+
+
+class TestSeedByUpload:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"my_seed.csv": my_seed_csv, "my_seed.yaml": my_seed_yaml}
+
+    def test_seed(self, project):
+        run_dbt(["build"])


### PR DESCRIPTION
### Description

resolve #279

Resolve issue #279, so that users can revert to pre-1.4.2 behaviour and avoid need for extra IAM permissions

## Models used to test - Optional
Tests are in the change  -  I was unable to find a quick way of verifying that the insert vs. upload method had been used but I checked debug lots (a log message indicates which strategy) and query logs to confirm that the correct number of rows were queryable

## Checklist
- [/] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [/] You kept your Pull Request small and focused on a single feature or bug fix.
- [/] You added unit testing when necessary
- [/] You added functional testing when necessary
