### PR TITLE
fix: source freshness (cast_timestamp for models without config field)

### DIFF
--- a/dbt/include/athena/macros/utils/timestamps.sql
+++ b/dbt/include/athena/macros/utils/timestamps.sql
@@ -8,7 +8,7 @@
 
 
 {% macro cast_timestamp(timestamp_col) -%}
-  {%- set config = model['config'] -%}
+  {%- set config = model.get('config', {}) -%}
   {%- set table_type = config.get('table_type', 'glue') -%}
   {%- if table_type == 'iceberg' -%}
     cast({{ timestamp_col }} as timestamp(6))


### PR DESCRIPTION
Hi team,
First of all, thanks a lot for what you are doing with this adapter. I'm really fascinated with your pace of implementing new important fratures.

### Description

Unfortunately bugfix #235 introduced new bug: now `dbt source freshness` does not work at all.
Looks like `config` field is not propagated to `model` object of source in timestamp macro.

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
