### PR TITLE
fix: functional test trigger fix

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,7 +1,8 @@
 name: functional-tests
 
 on:
-  pull_request:
+  pull_request_target: # Please read https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ before using
+    types: [ opened, edited ]
   push:
     branches: [main]
 


### PR DESCRIPTION
### Description

Functional tests are not accessing secrets from fork triggers or via dependantbot, this pr use pull_request_target at our own risk.



## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
