### PR TITLE
fix: functional tests remove conditions

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -2,7 +2,6 @@ name: functional-tests
 
 on:
   pull_request_target: # Please read https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ before using
-    types: [ opened, edited ]
   push:
     branches: [main]
 


### PR DESCRIPTION
### Description
Functional tests ci was not triggered anymore after merging this https://github.com/dbt-athena/dbt-athena/pull/297

Try to remove conditions on pull_request_target to see if it gets trigger.


## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
