### PR TITLE
fix: ha=true for tables was broken for first runs

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -41,7 +41,7 @@
   {%- if table_type == 'hive' -%}
 
     -- for ha tables that are not in full refresh mode and when the relation exists we use the swap behavior
-    {%- if is_ha and (not is_full_refresh_mode or old_relation is not none) -%}
+    {%- if is_ha and not is_full_refresh_mode and old_relation is not none -%}
       -- drop the tmp_relation
       {%- if tmp_relation is not none -%}
         {% call statement('drop_tmp_relation', auto_begin=False) -%}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -40,7 +40,8 @@
 
   {%- if table_type == 'hive' -%}
 
-    {%- if is_ha and not is_full_refresh_mode -%}
+    -- for ha tables that are not in full refresh mode and when the relation exists we use the swap behavior
+    {%- if is_ha and (not is_full_refresh_mode or old_relation is not none) -%}
       -- drop the tmp_relation
       {%- if tmp_relation is not none -%}
         {% call statement('drop_tmp_relation', auto_begin=False) -%}


### PR DESCRIPTION
### Description

Fix broken behavior for ha tables that was breaking in the first run, checking if the old table don't exists.


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
