### PR TITLE
fix: handle how edge cases in functional tests triggering

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -2,7 +2,6 @@ name: functional-tests
 
 on:
   pull_request_target: # Please read https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ before using
-    types: [ labeled ]
   push:
     branches: [main]
 
@@ -16,7 +15,7 @@ env:
 jobs:
   functional-tests:
     name: Functional Test
-    if: github.event.label.name == 'enable-functional-tests' || github.ref == 'refs/heads/main'
+    if: contains(github.event.pull_request.labels.*.name, 'enable-functional-tests') || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Description

In the current CI implementation of functional tests, we were able to trigger them only on:
* merge to main
* when  the  label `enable-functional-tests`  was added to the PR

But in reality, we want to trigger functional tests run also in all the cases where the PR is labelled, not only on the action of labeling.

Fix found thanks to [this](https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label): 


## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
