### PR TITLE
fix: functional test edge case github ref

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,6 +1,7 @@
 name: functional-tests
 
 on:
+  # we use pull_request_target to run the CI also for forks
   pull_request_target: # Please read https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ before using
     types: [opened, reopened, synchronize, labeled]
   push:
@@ -29,8 +30,21 @@ jobs:
       DBT_TEST_ATHENA_S3_STAGING_DIR: s3://dbt-athena-query-results-${{ matrix.aws-region }}
       DBT_TEST_ATHENA_REGION_NAME: ${{ matrix.aws-region }}
     steps:
+      # when triggering the pr using pull_request_target, GITHUB_REF is set to main branch
+      # this workaround allow to pick the correct branch name
+      - name: Set Target branch
+        run: |
+          if [ -n "${GITHUB_HEAD_REF}" ]; then
+            export TARGET_BRANCH=${GITHUB_HEAD_REF/refs\/heads\//}
+            echo "Running on PR branch ${TARGET_BRANCH}"
+          else
+            export TARGET_BRANCH=${GITHUB_REF_NAME}
+            echo "Running on branch ${TARGET_BRANCH}"
+          fi
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -123,7 +123,7 @@
   {%- set config = model['config'] -%}
 
   {%- set target_table = model.get('alias', model.get('name')) -%}
-  {%- set lf_tags_config = config.get('lf_tags_config') -%}
+  {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
   {%- set strategy_name = config.get('strategy') -%}
   {%- set file_format = config.get('file_format', 'parquet') -%}
   {%- set table_type = config.get('table_type', 'hive') -%}

--- a/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/athena/macros/materializations/snapshots/snapshot.sql
@@ -123,7 +123,7 @@
   {%- set config = model['config'] -%}
 
   {%- set target_table = model.get('alias', model.get('name')) -%}
-  {%- set lf_tags_config = config.get('lf_tags_config', default=none) -%}
+  {%- set lf_tags_config = config.get('lf_tags_config') -%}
   {%- set strategy_name = config.get('strategy') -%}
   {%- set file_format = config.get('file_format', 'parquet') -%}
   {%- set table_type = config.get('table_type', 'hive') -%}


### PR DESCRIPTION
### Description
When using pull_request_target GITHUB_REF, the default branch used in the checkout step, was set always to refs/head/main, but when running the tests on pr, this means that we were not able to spot the issues, as shown by this https://github.com/dbt-athena/dbt-athena/pull/313 - functional tests were ✅ , we merge it, and then we saw main broken.

This fix uses the GITHUB_HEAD_REF - that is set only for a pr, and if GITHUB_HEAD_REF is not set (e.g. merging to main), we pick GITHUB_REF.


## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
