### PR TITLE
chore: trim regions for functional testing

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
-        aws-region: ['us-east-1', 'eu-west-1', 'eu-west-2', 'eu-central-1']
+        aws-region: ['us-east-1', 'eu-central-1']
     permissions:
       id-token: write
       contents: read
@@ -35,7 +35,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
-        aws-region: ['us-east-1', 'eu-west-1', 'eu-west-2', 'eu-central-1']
+        aws-region: ['us-east-1', 'eu-central-1']
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
-        aws-region: ['us-east-1', 'eu-central-1']
+        aws-region: ['us-east-1', 'eu-west-1', 'eu-central-1']
     permissions:
       id-token: write
       contents: read
@@ -35,7 +35,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
-        aws-region: ['us-east-1', 'eu-central-1']
+        aws-region: ['us-east-1', 'eu-west-1', 'eu-central-1']
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
-        aws-region: ['us-east-1', 'eu-west-1', 'eu-central-1']
+        aws-region: ['us-east-1', 'eu-central-1']
     permissions:
       id-token: write
       contents: read
@@ -35,7 +35,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
-        aws-region: ['us-east-1', 'eu-west-1', 'eu-central-1']
+        aws-region: ['us-east-1', 'eu-central-1']
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### Description

As agreed with @mattiamatrix  to keep AWS cost low, let's remove some regions.
Specifically:
* us-east-1 is kept as quite some new features are pushed there - similar to eu-west-1
* eu-central-1 as we want to have a region in Europe that is used by users, and where upgrades are not coming so often.


