### PR TITLE
fix: check is_ha for iceberg tables

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -76,33 +76,39 @@
     {{ set_table_classification(target_relation) }}
 
   {%- else -%}
+    {%- if is_ha -%}
+      {%- if old_relation is none -%}
+        {%- call statement('main') -%}
+          {{ create_table_as(False, target_relation, sql) }}
+        {%- endcall %}
+      {%- else -%}
+        {%- if tmp_relation is not none -%}
+          {%- do drop_relation(tmp_relation) -%}
+        {%- endif -%}
 
-    {%- if old_relation is none -%}
+        {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
+        -- If we have this, it means that at least the first renaming occurred but there was an issue
+        -- afterwards, therefore we are in weird state. The easiest and cleanest should be to remove
+        -- the backup relation. It won't have an impact because since we are in the else condition,
+        -- that means that old relation exists therefore no downtime yet.
+        {%- if old_relation_bkp is not none -%}
+          {%- do drop_relation(old_relation_bkp) -%}
+        {%- endif -%}
+
+        {%- call statement('main') -%}
+          {{ create_table_as(False, tmp_relation, sql) }}
+        {%- endcall -%}
+
+        {{ rename_relation(old_relation, old_relation_bkp) }}
+        {{ rename_relation(tmp_relation, target_relation) }}
+
+        {{ drop_relation(old_relation_bkp) }}
+      {%- endif -%}
+    {%- else -%}
+      {%- do drop_relation(target_relation) -%}
       {%- call statement('main') -%}
         {{ create_table_as(False, target_relation, sql) }}
-      {%- endcall %}
-    {%- else -%}
-      {%- if tmp_relation is not none -%}
-        {%- do drop_relation(tmp_relation) -%}
-      {%- endif -%}
-
-      {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
-      -- If we have this, it means that at least the first renaming occurred but there was an issue
-      -- afterwards, therefore we are in weird state. The easiest and cleanest should be to remove
-      -- the backup relation. It won't have an impact because since we are in the else condition,
-      -- that means that old relation exists therefore no downtime yet.
-      {%- if old_relation_bkp is not none -%}
-        {%- do drop_relation(old_relation_bkp) -%}
-      {%- endif -%}
-
-      {%- call statement('main') -%}
-        {{ create_table_as(False, tmp_relation, sql) }}
       {%- endcall -%}
-
-      {{ rename_relation(old_relation, old_relation_bkp) }}
-      {{ rename_relation(tmp_relation, target_relation) }}
-
-      {{ drop_relation(old_relation_bkp) }}
     {%- endif -%}
 
   {%- endif -%}


### PR DESCRIPTION
### Description

resolve #331 

is_ha parameter not checked in cases other than iceberg tables. Adds a conditional to check and do a simple drop/create in false case.

There is probably still a bug under here in that HA tables will try to execute ALTER TABLE RENAME TO and that's not legal in Athena... but at least this means that you're not affected unless you're explicitly using HA iceberg tables (which is my case, so I'd really like to patch it up asap as it'll stop my team from updating)

## Models used to test - Optional
unit & func tests both all pass whether this is here or not. Not clear how best to add a useful test as looks like base tests are skipped

## Checklist
- [/] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [/] You kept your Pull Request small and focused on a single feature or bug fix.
- [/] You added unit testing when necessary
- [/] You added functional testing when necessary
