### PR TITLE
fix: Lakeformation tags in athena__create_csv_table macro

### DIFF
--- a/dbt/include/athena/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/athena/macros/materializations/seeds/helpers.sql
@@ -197,17 +197,6 @@
     {%- set sql_table = create_csv_table_upload(model, agate_table) -%}
   {%- endif -%}
 
-  {%- set lf_tags_config = config.get('lf_tags_config') -%}
-  {%- set lf_grants = config.get('lf_grants') -%}
-
-  {% if lf_tags_config is not none %}
-    {{ adapter.add_lf_tags(relation, lf_tags_config) }}
-  {% endif %}
-
-  {% if lf_grants is not none %}
-    {{ adapter.apply_lf_grants(relation, lf_grants) }}
-  {% endif %}
-
   {{ return(sql_table) }}
 {% endmacro %}
 


### PR DESCRIPTION
### Description

This is hotfix for athena__create_csv_table macro to avoid the following error:
```
09:57:59  Compilation Error in seed ref_action_type (seeds/ref_sources/ref_action_type.csv)
09:57:59    'relation' is undefined
```

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
