### PR TITLE
fix: enable persist_docs for views

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
     * Does **not** support the use of `unique_key`
 * Supports [snapshots][snapshots]
 * Does not support [Python models][python-models]
-* Does not support [persist docs][persist-docs] for views
 
 [seeds]: https://docs.getdbt.com/docs/building-a-dbt-project/seeds
 [incremental]: https://docs.getdbt.com/docs/build/incremental-models

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -685,7 +685,7 @@ class AthenaAdapter(SQLAdapter):
                     # Prepare column description from dbt
                     clean_col_comment = clean_sql_comment(col_comment)
                     # Get current column comment from Glue
-                    glue_col_comment = col_obj["Comment"]
+                    glue_col_comment = col_obj.get("Comment", "")
                     # Update column description if it's different
                     if glue_col_comment != clean_col_comment:
                         col_obj["Comment"] = clean_col_comment

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -645,19 +645,19 @@ class AthenaAdapter(SQLAdapter):
             glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
 
         # By default, there is no need to update Glue Table
-        need_udpate_table: bool = False
+        need_udpate_table = False
         # Get Table from Glue
-        table: Dict[str, Any] = glue_client.get_table(DatabaseName=relation.schema, Name=relation.name)["Table"]
+        table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.name)["Table"]
         # Prepare new version of Glue Table picking up significant fields
-        updated_table: Dict[str, Any] = self._get_table_input(table)
+        updated_table = self._get_table_input(table)
         # Update table description
         if persist_relation_docs:
             # Prepare dbt description
-            clean_table_description: str = clean_sql_comment(model["description"])
+            clean_table_description = clean_sql_comment(model["description"])
             # Get current description from Glue
-            current_table_description: str = table.get("Description", "")
+            current_table_description = table.get("Description", "")
             # Get current description parameter from Glue
-            current_table_comment: str = table["Parameters"].get("comment", "")
+            current_table_comment = table["Parameters"].get("comment", "")
             # Update description if it's different
             if clean_table_description != current_table_description or clean_table_description != current_table_comment:
                 updated_table["Description"] = clean_table_description
@@ -667,16 +667,15 @@ class AthenaAdapter(SQLAdapter):
         # Update column comments
         if persist_column_docs:
             # Process every column
-            col_obj: Dict[str, Any]
             for col_obj in updated_table["StorageDescriptor"]["Columns"]:
                 # Get column description from dbt
-                col_name: str = col_obj["Name"]
-                col_comment: Optional[str] = model["columns"].get(col_name, {}).get("description", None)
+                col_name = col_obj["Name"]
+                col_comment = model["columns"].get(col_name, {}).get("description", None)
                 if col_comment is not None:
                     # Get current column comment from Glue
-                    current_col_comment: str = col_obj.get("Comment", "")
+                    current_col_comment = col_obj.get("Comment", "")
                     # Prepare column description from dbt
-                    clean_col_comment: str = clean_sql_comment(col_comment)
+                    clean_col_comment = clean_sql_comment(col_comment)
                     # Update column description if it's different
                     if current_col_comment != clean_col_comment:
                         col_obj["Comment"] = clean_col_comment
@@ -856,7 +855,7 @@ class AthenaAdapter(SQLAdapter):
         return isinstance(value, list)
 
     @staticmethod
-    def _get_table_input(table: Dict[str, Any]) -> Dict[str, Any]:
+    def _get_table_input(table):
         """
         Prepare Glue Table dictionary to be a table_input argument of update_table() method.
 
@@ -864,7 +863,7 @@ class AthenaAdapter(SQLAdapter):
         returned by get_table() method.
         This code was derived from awswrangler==3.2.1.
         """
-        table_input: Dict[str, Any] = {}
+        table_input = {}
         for k, v in table.items():
             if k in [
                 "Name",

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -855,7 +855,7 @@ class AthenaAdapter(SQLAdapter):
         return isinstance(value, list)
 
     @staticmethod
-    def _get_table_input(table):
+    def _get_table_input(table: Dict[str, Any]) -> Dict[str, Any]:
         """
         Prepare Glue Table dictionary to be a table_input argument of update_table() method.
 
@@ -863,7 +863,7 @@ class AthenaAdapter(SQLAdapter):
         returned by get_table() method.
         This code was derived from awswrangler==3.2.1.
         """
-        table_input = {}
+        table_input: Dict[str, Any] = {}
         for k, v in table.items():
             if k in [
                 "Name",

--- a/dbt/include/athena/macros/adapters/persist_docs.sql
+++ b/dbt/include/athena/macros/adapters/persist_docs.sql
@@ -2,7 +2,7 @@
   {% set persist_relation_docs = for_relation and config.persist_relation_docs() and model.description %}
   {% set persist_column_docs = for_columns and config.persist_column_docs() and model.columns %}
   {% set skip_archive = not is_incremental() %}
-  {% if (persist_relation_docs or persist_column_docs) %}
+  {% if persist_relation_docs or persist_column_docs %}
     {% do adapter.persist_docs_to_glue(relation,
                                        model,
                                        persist_relation_docs,

--- a/dbt/include/athena/macros/adapters/persist_docs.sql
+++ b/dbt/include/athena/macros/adapters/persist_docs.sql
@@ -1,12 +1,12 @@
 {% macro athena__persist_docs(relation, model, for_relation, for_columns) -%}
   {% set persist_relation_docs = for_relation and config.persist_relation_docs() and model.description %}
   {% set persist_column_docs = for_columns and config.persist_column_docs() and model.columns %}
-  {% set skip_archive = not is_incremental() %}
+  {% set skip_archive_table_version = not is_incremental() %}
   {% if persist_relation_docs or persist_column_docs %}
     {% do adapter.persist_docs_to_glue(relation,
                                        model,
                                        persist_relation_docs,
                                        persist_column_docs,
-                                       skip_archive=skip_archive) %}}
+                                       skip_archive_table_version=skip_archive_table_version) %}}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/athena/macros/adapters/persist_docs.sql
+++ b/dbt/include/athena/macros/adapters/persist_docs.sql
@@ -1,10 +1,12 @@
 {% macro athena__persist_docs(relation, model, for_relation, for_columns) -%}
   {% set persist_relation_docs = for_relation and config.persist_relation_docs() and model.description %}
   {% set persist_column_docs = for_columns and config.persist_column_docs() and model.columns %}
+  {% set skip_archive = not is_incremental() %}
   {% if (persist_relation_docs or persist_column_docs) %}
     {% do adapter.persist_docs_to_glue(relation,
                                        model,
                                        persist_relation_docs,
-                                       persist_column_docs) %}}
+                                       persist_column_docs,
+                                       skip_archive=skip_archive) %}}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/athena/macros/adapters/persist_docs.sql
+++ b/dbt/include/athena/macros/adapters/persist_docs.sql
@@ -1,7 +1,7 @@
 {% macro athena__persist_docs(relation, model, for_relation, for_columns) -%}
   {% set persist_relation_docs = for_relation and config.persist_relation_docs() and model.description %}
   {% set persist_column_docs = for_columns and config.persist_column_docs() and model.columns %}
-  {% if (persist_relation_docs or persist_column_docs) and relation.type != 'view' %}
+  {% if (persist_relation_docs or persist_column_docs) %}
     {% do adapter.persist_docs_to_glue(relation,
                                        model,
                                        persist_relation_docs,

--- a/dbt/include/athena/macros/materializations/models/view/view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/view.sql
@@ -2,6 +2,7 @@
     {% set to_return = create_or_replace_view(run_outside_transaction_hooks=False) %}
 
     {% set target_relation = this.incorporate(type='view') %}
+    {% do persist_docs(target_relation, model) %}
 
     {% do return(to_return) %}
 {%- endmaterialization %}


### PR DESCRIPTION
### Description

Since Athena view is just a Glue table it's an omission that persist_docs feature is disabled for views. It works exactly the same as with Athena tables.


## Checklist
- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [X] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
