### PR TITLE
fix: fix unexpected error rendering columns missing data_type

### DIFF
--- a/dbt/include/athena/macros/adapters/columns.sql
+++ b/dbt/include/athena/macros/adapters/columns.sql
@@ -9,8 +9,9 @@
       {%- set col = columns[i] -%}
       {%- if col['data_type'] is not defined -%}
         {{ col_err.append(col['name']) }}
+      {%- else -%}
+        cast(null as {{ dml_data_type(col['data_type']) }}) as {{ col['name'] }}{{ ", " if not loop.last }}
       {%- endif -%}
-      cast(null as {{ dml_data_type(col['data_type']) }}) as {{ col['name'] }}{{ ", " if not loop.last }}
     {%- endfor -%}
     {%- if (col_err | length) > 0 -%}
       {{ exceptions.column_type_missing(column_names=col_err) }}


### PR DESCRIPTION
### Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

When setting contract is enforced and `data_type` of column is missing, the following error is shown.
```
08:14:27    expected string or bytes-like object
08:14:27
08:14:27    > in macro athena__get_empty_schema_sql (macros/adapters/columns.sql)
08:14:27    > called by macro get_empty_schema_sql (macros/adapters/columns.sql)
08:14:27    > called by macro assert_columns_equivalent (macros/materializations/models/table/columns_spec_ddl.sql)
08:14:27    > called by macro default__get_assert_columns_equivalent (macros/materializations/models/table/columns_spec_ddl.sql)
08:14:27    > called by macro get_assert_columns_equivalent (macros/materializations/models/table/columns_spec_ddl.sql)
08:14:27    > called by macro athena__create_table_as (macros/materializations/models/table/create_table_as.sql)
08:14:27    > called by macro create_table_as (macros/materializations/models/table/create_table_as.sql)
08:14:27    > called by macro statement (macros/etc/statement.sql)
08:14:27    > called by macro materialization_table_athena (macros/materializations/models/table/table.sql)
```
This error is occurred because the macro trying to render a cast query for the invalid column,  though expected behavior is to show the list of columns missing `data_type`.
This PR fixes this issue

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
