### PR TITLE
feat: add catalog_name param to AthenaConnection handle

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -203,6 +203,7 @@ class AthenaConnectionManager(SQLConnectionManager):
             handle = AthenaConnection(
                 s3_staging_dir=creds.s3_staging_dir,
                 endpoint_url=creds.endpoint_url,
+                catalog_name=creds.database,
                 schema_name=creds.schema,
                 work_group=creds.work_group,
                 cursor_class=AthenaCursor,


### PR DESCRIPTION
Fixes #359 

### Description

Currently, the Glue catalog value is not being passed as a parameter in the AthenaConnection call.

When attempting to use a catalog other than the default (awsdatacatalog), the following error is displayed:

```
botocore.errorfactory.InvalidRequestException: An error occurred (InvalidRequestException) when calling the StartQueryExecution operation: Unsupported ddl with 2 catalogs: ...*/
```

The solution now includes the addition of the 'catalog_name' parameter to the AthenaConnection handle.

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
