### PR TITLE
chore: bump dbt-core to 1.6.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jessedobbelaere @Jrmyy @mattiamatrix @nicor88 @svdimchenko @thenaturalist
+* @jessedobbelaere @Jrmyy @mattiamatrix @nicor88 @svdimchenko

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 <p align="center">
     <img src="https://raw.githubusercontent.com/dbt-athena/dbt-athena/main/static/images/dbt-athena-long.png" />
     <a href="https://pypi.org/project/dbt-athena-community/"><img src="https://badge.fury.io/py/dbt-athena-community.svg" /></a>
+    <a target="_blank" href="https://pypi.org/project/dlt/" style="background:none">
+      <img src="https://img.shields.io/pypi/pyversions/dbt-athena-community">
+    </a>
     <a href="https://pycqa.github.io/isort/"><img src="https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336" /></a>
     <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg" /></a>
     <a href="https://github.com/python/mypy"><img src="https://www.mypy-lang.org/static/mypy_badge.svg" /></a>
-    <a href="https://pepy.tech/project/dbt-athena-community"><img src="https://pepy.tech/badge/dbt-athena-community/month" /></a>
+    <a href="https://pepy.tech/project/dbt-athena-community"><img src="https://static.pepy.tech/badge/dbt-athena-community/month" /></a>
 </p>
 
 ## Features
 
-* Supports dbt version `1.5.*`
+* Supports dbt version `1.6.*`
+* Supports from Python
 * Supports [seeds][seeds]
 * Correctly detects views and their columns
 * Supports [table materialization][table]

--- a/dbt/adapters/athena/__version__.py
+++ b/dbt/adapters/athena/__version__.py
@@ -1,1 +1,1 @@
-version = "1.5.2"
+version = "1.6.0"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 autoflake~=1.7
 black~=23.3
-dbt-tests-adapter~=1.5.4
+dbt-tests-adapter~=1.6.0
 flake8~=5.0
 Flake8-pyproject~=1.2
 isort~=5.11

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         # In order to control dbt-core version and package version
         "boto3~=1.26",
         "boto3-stubs[athena,glue,lakeformation,sts]~=1.26",
-        "dbt-core~=1.5.0",
+        "dbt-core~=1.6.0",
         "pyathena>=2.25,<4.0",
         "pydantic>=1.10,<3.0",
         "tenacity~=8.2",
@@ -66,7 +66,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def _get_package_version() -> str:
     return f'{parts["major"]}.{parts["minor"]}.{parts["patch"]}'
 
 
-dbt_version = "1.5"
+dbt_version = "1.6"
 package_version = _get_package_version()
 description = "The athena adapter plugin for dbt (data build tool)"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from dbt.events.base_types import EventLevel
 from dbt.events.eventmgr import LineFormat, NoFilter
 from dbt.events.functions import EVENT_MANAGER, _get_stdout_config
 
-# Import the fuctional fixtures as a plugin
+# Import the functional fixtures as a plugin
 # Note: fixtures with session scope need to be local
 
 pytest_plugins = ["dbt.tests.fixtures.project"]
@@ -42,11 +42,14 @@ def dbt_debug_caplog() -> StringIO:
 
 def _setup_custom_caplog(name: str, level: EventLevel):
     capture_config = _get_stdout_config(
-        line_format=LineFormat.PlainText, level=level, use_colors=False, debug=True, log_cache_events=True, quiet=False
+        line_format=LineFormat.PlainText,
+        level=level,
+        use_colors=False,
+        log_cache_events=True,
     )
     capture_config.name = name
     capture_config.filter = NoFilter
-    stringbuf = StringIO()
-    capture_config.output_stream = stringbuf
+    string_buf = StringIO()
+    capture_config.output_stream = string_buf
     EVENT_MANAGER.add_logger(capture_config)
-    return stringbuf
+    return string_buf

--- a/tests/functional/adapter/fixture_split_parts.py
+++ b/tests/functional/adapter/fixture_split_parts.py
@@ -1,0 +1,39 @@
+models__test_split_part_sql = """
+with data as (
+
+    select * from {{ ref('data_split_part') }}
+
+)
+
+select
+    {{ split_part('parts', 'split_on', 1) }} as actual,
+    result_1 as expected
+
+from data
+
+union all
+
+select
+    {{ split_part('parts', 'split_on', 2) }} as actual,
+    result_2 as expected
+
+from data
+
+union all
+
+select
+    {{ split_part('parts', 'split_on', 3) }} as actual,
+    result_3 as expected
+
+from data
+"""
+
+models__test_split_part_yml = """
+version: 2
+models:
+  - name: test_split_part
+    tests:
+      - assert_equal:
+          actual: actual
+          expected: expected
+"""

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -3,6 +3,10 @@ from tests.functional.adapter.fixture_datediff import (
     models__test_datediff_sql,
     seeds__data_datediff_csv,
 )
+from tests.functional.adapter.fixture_split_parts import (
+    models__test_split_part_sql,
+    models__test_split_part_yml,
+)
 
 from dbt.tests.adapter.utils.fixture_datediff import models__test_datediff_yml
 from dbt.tests.adapter.utils.test_any_value import BaseAnyValue
@@ -100,7 +104,12 @@ class TestRight(BaseRight):
 
 
 class TestSplitPart(BaseSplitPart):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_split_part.yml": models__test_split_part_yml,
+            "test_split_part.sql": self.interpolate_macro_namespace(models__test_split_part_sql, "split_part"),
+        }
 
 
 class TestStringLiteral(BaseStringLiteral):


### PR DESCRIPTION
### Description

* Bump dbt core to 1.6.0
* drop support for Python 3.7


No major change in the adapter so far. The only feature worth adding is `dbt clone` - we should consider to do it separately .

## TODO
- [x] Fix unit testing
- [x] bump dbt-tests 
- [ ] Adapt breaking function tests

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
