### PR TITLE
Fix add varbinary column type for iceberg tables

### DIFF
--- a/dbt/include/athena/macros/utils/ddl_dml_data_type.sql
+++ b/dbt/include/athena/macros/utils/ddl_dml_data_type.sql
@@ -18,8 +18,14 @@
   {%- endif -%}
 
   -- transform timestamp
-  {%- if table_type == 'iceberg' and 'timestamp' in data_type -%}
-    {% set data_type = 'timestamp' -%}
+  {%- if table_type == 'iceberg' -%}
+    {%- if 'timestamp' in data_type -%}
+        {% set data_type = 'timestamp' -%}
+    {%- endif -%}
+
+    {%- if 'binary' in data_type -%}
+        {% set data_type = 'binary' -%}
+    {%- endif -%}
   {%- endif -%}
 
   {{ return(data_type) }}


### PR DESCRIPTION
### Description
Fix error while executing sql query for adding varbinary column for iceberg tables:
```
alter table db_schema.table add columns (test_column varbinary);
```
Added: replace ddl column type for iceberg table from `varbinary` to `binary`. 

## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
