### PR TITLE
feat: Implement configurable debug_query_state parameter for AthenaCursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ A dbt profile can be configured to run against AWS Athena using the following co
 | schema                | Specify the schema (Athena database) to build models into (lowercase **only**) | Required  | `dbt`                                      |
 | database              | Specify the database (Data catalog) to build models into (lowercase **only**)  | Required  | `awsdatacatalog`                           |
 | poll_interval         | Interval in seconds to use for polling the status of query results in Athena   | Optional  | `5`                                        |
+| debug_query_state     | Flag if debug message with Athena query state is needed                        | Optional  | `false`                                    |
 | aws_access_key_id     | Access key ID of the user performing requests.                                 | Optional  | `AKIAIOSFODNN7EXAMPLE`                     |
 | aws_secret_access_key | Secret access key of the user performing requests                              | Optional  | `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` |
 | aws_profile_name      | Profile to use from your AWS shared credentials file.                          | Optional  | `my-profile`                               |


### PR DESCRIPTION
### Description

Now we can configure if we do need to debug query state in following way:
```
11:36:44  Athena adapter: Query state is: QUEUED. Sleeping for 1.0...
11:36:45  Athena adapter: Query state is: RUNNING. Sleeping for 1.0...
11:36:46  Athena adapter: Query state is: RUNNING. Sleeping for 1.0...
11:36:47  Athena adapter: Query state is: RUNNING. Sleeping for 1.0...
```

By default, it's disabled.

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [] You added unit testing when necessary
- [] You added functional testing when necessary
