### PR TITLE
fix: Use importlib.metadata.version() to remove implicit dependency on `setuptools`

### DIFF
--- a/dbt/adapters/athena/config.py
+++ b/dbt/adapters/athena/config.py
@@ -1,11 +1,9 @@
+import importlib.metadata
 from functools import lru_cache
 
-import pkg_resources
 from botocore import config
 
 
 @lru_cache()
 def get_boto3_config() -> config.Config:
-    return config.Config(
-        user_agent_extra="dbt-athena-community/" + pkg_resources.get_distribution("dbt-athena-community").version
-    )
+    return config.Config(user_agent_extra="dbt-athena-community/" + importlib.metadata.version("dbt-athena-community"))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,13 +1,12 @@
+import importlib.metadata
 from unittest.mock import Mock
-
-import pkg_resources
 
 from dbt.adapters.athena.config import get_boto3_config
 
 
 class TestConfig:
     def test_get_boto3_config(self):
-        pkg_resources.get_distribution = Mock(return_value=pkg_resources.Distribution(version="2.4.6"))
+        importlib.metadata.version = Mock(return_value="2.4.6")
         get_boto3_config.cache_clear()
         config = get_boto3_config()
         assert config._user_provided_options["user_agent_extra"] == "dbt-athena-community/2.4.6"


### PR DESCRIPTION
## Description
- Currently dbt-athena implicitly depends on `setuptools` as it imports `pkg_resources`.
- Use `importlib.metadata` from the stdlib to remove the implicit dependency.

### Our context
- We are using [bazel](https://bazel.build) with [rules_python](https://github.com/bazelbuild/rules_python) in our project. We need to tell bazel the exact set of dependencies of our application (including standard/common libraries such as `setuptools`).
- `dbt-athena` currently does not declare an explicit dependency on `setuptools`, so bazel and rules_python do not know the fact that `setuptools` is needed via `dbt-athena`.
- Adding `setuptools` as a dependency of `dbt-athena` in `setup.py` is a possible solution, but I think it's simpler to use stdlib API and remove the implicit dependency.

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->
None

## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary : (the existing test already covers the changed code)
- [ ] You added functional testing when necessary