### PR TITLE
fix: add sql query logger

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -952,6 +952,7 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         cursor = conn.handle.cursor()
         try:
+            LOGGER.debug(sql)
             cursor.execute(sql, catch_partitions_limit=True)
         except OperationalError as e:
             LOGGER.debug(f"CAUGHT EXCEPTION: {e}")


### PR DESCRIPTION
### Description
Somehow since v1.5.2 queries are not logged anymore when running in debug mode.
This PR aims to add a logger.debug with the executed SQL in run_query_with_partitions_limit_catchin.

I'm not entirely sure that this is the root cause - but should help


## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
