### PR TITLE
fix: render relation in case of we hit partition limits

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -124,7 +124,7 @@
     {%- do log('QUERY RESULT: ' ~ query_result) -%}
     {%- if query_result == 'TOO_MANY_OPEN_PARTITIONS' -%}
       {%- do create_table_as_with_partitions(temporary, relation, sql) -%}
-      {%- set query_result = '{{ relation }} with many partitions created' -%}
+      {%- set query_result = relation ~ ' with many partitions created' -%}
     {%- endif -%}
     {{ return(query_result) }}
 {%- endmacro %}


### PR DESCRIPTION
### Description
Small fix to put the actual relation in the logging.

Before fix
```
{{ relation }} with many partitions created
```
After fix

```
 '"awsdatacatalog"."dbt_nicola"."test_partitions" with many partitions created';
```



## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
