### PR TITLE
fix: catalogId cannot be None in glue client

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -231,7 +231,10 @@ class AthenaAdapter(SQLAdapter):
             glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
 
         try:
-            table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.identifier)
+            if catalog_id is not None:
+                table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.identifier)
+            else:
+                table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.identifier)
         except ClientError as e:
             if e.response["Error"]["Code"] == "EntityNotFoundException":
                 LOGGER.debug(f"Table {relation.render()} does not exists - Ignoring")
@@ -753,7 +756,10 @@ class AthenaAdapter(SQLAdapter):
         # By default, there is no need to update Glue Table
         need_udpate_table = False
         # Get Table from Glue
-        table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.name)["Table"]
+        if catalog_id is not None:
+            table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.name)["Table"]
+        else:
+            table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.name)["Table"]
         # Prepare new version of Glue Table picking up significant fields
         updated_table = self._get_table_input(table)
         # Update table description
@@ -834,9 +840,10 @@ class AthenaAdapter(SQLAdapter):
             glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
 
         try:
-            table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.identifier)[
-                "Table"
-            ]
+            if catalog_id is not None:
+                table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.identifier)["Table"]
+            else:
+                table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.identifier)["Table"]
         except ClientError as e:
             if e.response["Error"]["Code"] == "EntityNotFoundException":
                 LOGGER.debug("table not exist, catching the error")
@@ -871,7 +878,10 @@ class AthenaAdapter(SQLAdapter):
             glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
 
         try:
-            glue_client.delete_table(CatalogId=catalog_id, DatabaseName=schema_name, Name=table_name)
+            if catalog_id is not None:
+                glue_client.delete_table(CatalogId=catalog_id, DatabaseName=schema_name, Name=table_name)
+            else:
+                glue_client.delete_table(DatabaseName=schema_name, Name=table_name)
             LOGGER.debug(f"Deleted table from glue catalog: {relation.render()}")
         except ClientError as e:
             if e.response["Error"]["Code"] == "EntityNotFoundException":

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -232,7 +232,9 @@ class AthenaAdapter(SQLAdapter):
 
         try:
             if catalog_id is not None:
-                table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.identifier)
+                table = glue_client.get_table(
+                    CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.identifier
+                )
             else:
                 table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.identifier)
         except ClientError as e:
@@ -757,7 +759,9 @@ class AthenaAdapter(SQLAdapter):
         need_udpate_table = False
         # Get Table from Glue
         if catalog_id is not None:
-            table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.name)["Table"]
+            table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.name)[
+                "Table"
+            ]
         else:
             table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.name)["Table"]
         # Prepare new version of Glue Table picking up significant fields
@@ -841,7 +845,9 @@ class AthenaAdapter(SQLAdapter):
 
         try:
             if catalog_id is not None:
-                table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.identifier)["Table"]
+                table = glue_client.get_table(
+                    CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.identifier
+                )["Table"]
             else:
                 table = glue_client.get_table(DatabaseName=relation.schema, Name=relation.identifier)["Table"]
         except ClientError as e:


### PR DESCRIPTION
### Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->
Resolves #410 

Glue client does not seem to support passing None: `CatalogId=None`. It fails with:

```
Parameter validation failed:
Invalid type for parameter CatalogId, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
```

<img width="878" alt="image" src="https://github.com/dbt-athena/dbt-athena/assets/1352979/c96f7ad9-cdd6-4cd8-afe9-fa74f7d760b1">

AWS mentions "if none is provided" but passing `None` makes the glue client fail 😅 

Looking at other AWS code, it seems they add an if-check on `CatalogId`: https://github.com/felipemsantos/aws-data-wrangler/blob/d93b8a3527575536e77bd500bf60c86cd6676b6c/awswrangler/s3/_read_parquet.py#L733-L736

I used if/else instead of spreading `**args` but if that's cleaner I can switch over the code to that syntax? Let me know your preferences

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->


## Checklist
- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
