### PR TITLE
fix: improve get_partition_batches to treat integers properly

### DIFF
--- a/dbt/include/athena/macros/materializations/models/helpers/get_partition_batches.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers/get_partition_batches.sql
@@ -28,7 +28,7 @@
             {%- if col is none -%}
                 {%- set value = 'null' -%}
                 {%- set comp_func = ' is ' -%}
-            {%- elif column_type == 'integer' -%}
+            {%- elif column_type == 'integer' or column_type is none -%}
                 {%- set value = col | string -%}
             {%- elif column_type == 'string' -%}
                 {%- set value = "'" + col + "'" -%}
@@ -36,8 +36,6 @@
                 {%- set value = "DATE'" + col | string + "'" -%}
             {%- elif column_type == 'timestamp' -%}
                 {%- set value = "TIMESTAMP'" + col | string + "'" -%}
-            {%- elif column_type is none -%}
-                {%- set value = col | string -%}
             {%- else -%}
                 {%- do exceptions.raise_compiler_error('Need to add support for column type ' + column_type) -%}
             {%- endif -%}

--- a/dbt/include/athena/macros/materializations/models/helpers/get_partition_batches.sql
+++ b/dbt/include/athena/macros/materializations/models/helpers/get_partition_batches.sql
@@ -36,6 +36,8 @@
                 {%- set value = "DATE'" + col | string + "'" -%}
             {%- elif column_type == 'timestamp' -%}
                 {%- set value = "TIMESTAMP'" + col | string + "'" -%}
+            {%- elif column_type is none -%}
+                {%- set value = col | string -%}
             {%- else -%}
                 {%- do exceptions.raise_compiler_error('Need to add support for column type ' + column_type) -%}
             {%- endif -%}


### PR DESCRIPTION
### Description
Our functional tests were failing, specifically, the failures seem due only to cases where we deal with partitions and partitions being integers.

In case we one partition that is an integer, `adapter.convert_type` returns None, not integer, as you can see from [here](https://github.com/dbt-labs/dbt-core/compare/v1.6.2...v1.6.3#diff-2eee7e45ddbdac7ecdd8458a1c8c6b0d6d0c7dc6169e321eb2ab7a537f4171b1R20-R21).

This PR treats integers and None types equally - assuming that None types are actually integer.

This issue should be actually fixed in dbt-core, but for now we add this workaround.



## Checklist
- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
