### PR TITLE
feat(persist_docs): write dbt model and project metadata to properties

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -835,7 +835,7 @@ class AthenaAdapter(SQLAdapter):
             # Get dbt model meta if available
             meta: dict[str, Any] = model.get("config", {}).get("meta", {})
             # Add some of dbt model config fields as table meta
-            meta["unique_id"] = model["unique_id"]
+            meta["unique_id"] = model.get("unique_id")
             meta["materialized"] = model.get("config", {}).get("materialized")
             # Get dbt runtime config to be able to get dbt project metadata
             runtime_config: RuntimeConfig = self.config

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -817,7 +817,7 @@ class AthenaAdapter(SQLAdapter):
         table = glue_client.get_table(CatalogId=catalog_id, DatabaseName=relation.schema, Name=relation.name)["Table"]
         # Prepare new version of Glue Table picking up significant fields
         table_input = self._get_table_input(table)
-        table_parameters: Dict[str, str] = dict(table_input["Parameters"])
+        table_parameters = table_input["Parameters"]
         # Update table description
         if persist_relation_docs:
             # Prepare dbt description
@@ -833,7 +833,7 @@ class AthenaAdapter(SQLAdapter):
                 need_to_update_table = True
 
             # Get dbt model meta if available
-            meta: dict[str, Any] = model.get("config", {}).get("meta", {})
+            meta: Dict[str, Any] = model.get("config", {}).get("meta", {})
             # Add some of dbt model config fields as table meta
             meta["unique_id"] = model.get("unique_id")
             meta["materialized"] = model.get("config", {}).get("materialized")

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -855,9 +855,9 @@ class AthenaAdapter(SQLAdapter):
                             table_parameters[meta_key] = meta_value
                             need_to_update_table = True
                     else:
-                        LOGGER.warning('Meta value for key "%s" is not supported and will be ignored', meta_key)
+                        LOGGER.warning(f"Meta value for key '{meta_key}' is not supported and will be ignored")
                 else:
-                    LOGGER.warning('Meta key "%s" is not supported and will be ignored', meta_key)
+                    LOGGER.warning(f"Meta key '{meta_key}' is not supported and will be ignored")
 
         # Update column comments
         if persist_column_docs:

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -847,12 +847,17 @@ class AthenaAdapter(SQLAdapter):
             for meta_key, meta_value_raw in meta.items():
                 if is_valid_table_parameter_key(meta_key):
                     meta_value = stringify_table_parameter_value(meta_value_raw)
-                    # Check that meta value is already attached to Glue table
-                    current_meta_value: Optional[str] = table_parameters.get(meta_key)
-                    if current_meta_value is None or current_meta_value != meta_value:
-                        # Update Glue table parameter only if needed
-                        table_parameters[meta_key] = meta_value
-                        need_to_update_table = True
+                    if meta_value is not None:
+                        # Check that meta value is already attached to Glue table
+                        current_meta_value: Optional[str] = table_parameters.get(meta_key)
+                        if current_meta_value is None or current_meta_value != meta_value:
+                            # Update Glue table parameter only if needed
+                            table_parameters[meta_key] = meta_value
+                            need_to_update_table = True
+                    else:
+                        LOGGER.warning('Meta value for key "%s" is not supported and will be ignored', meta_key)
+                else:
+                    LOGGER.warning('Meta key "%s" is not supported and will be ignored', meta_key)
 
         # Update column comments
         if persist_column_docs:

--- a/dbt/adapters/athena/utils.py
+++ b/dbt/adapters/athena/utils.py
@@ -12,13 +12,9 @@ def clean_sql_comment(comment: str) -> str:
 
 def stringify_for_table_property(value: Any) -> str:
     """Convert any variable to string for Glue Table property."""
-    if isinstance(value, (str, bool, int, float)):
-        # Convert simple formats to strings
-        value_str: str = str(value)
-    else:
-        # Convert complex format to json string
-        value_str = json.dumps(value)
-    return value_str
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return str(value)
 
 
 def get_catalog_id(catalog: Optional[DataCatalogTypeDef]) -> Optional[str]:

--- a/dbt/adapters/athena/utils.py
+++ b/dbt/adapters/athena/utils.py
@@ -1,5 +1,6 @@
+import json
 from enum import Enum
-from typing import Generator, List, Optional, TypeVar
+from typing import Any, Generator, List, Optional, TypeVar
 
 from mypy_boto3_athena.type_defs import DataCatalogTypeDef
 
@@ -7,6 +8,17 @@ from mypy_boto3_athena.type_defs import DataCatalogTypeDef
 def clean_sql_comment(comment: str) -> str:
     split_and_strip = [line.strip() for line in comment.split("\n")]
     return " ".join(line for line in split_and_strip if line)
+
+
+def stringify_for_table_property(value: Any) -> str:
+    """Convert any variable to string for Glue Table property."""
+    if isinstance(value, (str, bool, int, float)):
+        # Convert simple formats to strings
+        value_str: str = str(value)
+    else:
+        # Convert complex format to json string
+        value_str = json.dumps(value)
+    return value_str
 
 
 def get_catalog_id(catalog: Optional[DataCatalogTypeDef]) -> Optional[str]:

--- a/dbt/adapters/athena/utils.py
+++ b/dbt/adapters/athena/utils.py
@@ -5,23 +5,26 @@ from typing import Any, Generator, List, Optional, TypeVar
 
 from mypy_boto3_athena.type_defs import DataCatalogTypeDef
 
+from dbt.adapters.athena.constants import LOGGER
+
 
 def clean_sql_comment(comment: str) -> str:
     split_and_strip = [line.strip() for line in comment.split("\n")]
     return " ".join(line for line in split_and_strip if line)
 
 
-def stringify_table_parameter_value(value: Any) -> str:
+def stringify_table_parameter_value(value: Any) -> Optional[str]:
     """Convert any variable to string for Glue Table property."""
     try:
         if isinstance(value, (dict, list)):
             value_str: str = json.dumps(value)
         else:
             value_str = str(value)
+        return value_str[:512000]
     except (TypeError, ValueError) as e:
         # Handle non-stringifiable objects and non-serializable objects
-        value_str = f"Non-stringifiable object. Error: {str(e)}"
-    return value_str[:512000]
+        LOGGER.warning("Non-stringifiable object. Error: %s", str(e))
+        return None
 
 
 def is_valid_table_parameter_key(key: str) -> bool:

--- a/dbt/adapters/athena/utils.py
+++ b/dbt/adapters/athena/utils.py
@@ -13,15 +13,23 @@ def clean_sql_comment(comment: str) -> str:
 
 def stringify_table_parameter_value(value: Any) -> str:
     """Convert any variable to string for Glue Table property."""
-    if isinstance(value, (dict, list)):
-        value_str: str = json.dumps(value)
-    else:
-        value_str = str(value)
+    try:
+        if isinstance(value, (dict, list)):
+            value_str: str = json.dumps(value)
+        else:
+            value_str = str(value)
+    except (TypeError, ValueError) as e:
+        # Handle non-stringifiable objects and non-serializable objects
+        value_str = f"Non-stringifiable object: {type(value)}, Error: {str(e)}"
     return value_str[:512000]
 
 
 def is_valid_table_parameter_key(key: str) -> bool:
-    return len(key) <= 255 and bool(re.match(r"^[\u0020-\uD7FF\uE000-\uFFFD\t]*$", key))
+    """Check if key is valid for Glue Table property according to official documentation."""
+    # Simplified version of key pattern which works with re
+    # Original pattern can be found here https://docs.aws.amazon.com/glue/latest/webapi/API_Table.html
+    key_pattern: str = r"^[\u0020-\uD7FF\uE000-\uFFFD\t]*$"
+    return len(key) <= 255 and bool(re.match(key_pattern, key))
 
 
 def get_catalog_id(catalog: Optional[DataCatalogTypeDef]) -> Optional[str]:

--- a/dbt/adapters/athena/utils.py
+++ b/dbt/adapters/athena/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from enum import Enum
 from typing import Any, Generator, List, Optional, TypeVar
 
@@ -10,11 +11,17 @@ def clean_sql_comment(comment: str) -> str:
     return " ".join(line for line in split_and_strip if line)
 
 
-def stringify_for_table_property(value: Any) -> str:
+def stringify_table_parameter_value(value: Any) -> str:
     """Convert any variable to string for Glue Table property."""
     if isinstance(value, (dict, list)):
-        return json.dumps(value)
-    return str(value)
+        value_str: str = json.dumps(value)
+    else:
+        value_str = str(value)
+    return value_str[:512000]
+
+
+def is_valid_table_parameter_key(key: str) -> bool:
+    return len(key) <= 255 and bool(re.match(r"^[\u0020-\uD7FF\uE000-\uFFFD\t]*$", key))
 
 
 def get_catalog_id(catalog: Optional[DataCatalogTypeDef]) -> Optional[str]:

--- a/dbt/adapters/athena/utils.py
+++ b/dbt/adapters/athena/utils.py
@@ -23,7 +23,7 @@ def stringify_table_parameter_value(value: Any) -> Optional[str]:
         return value_str[:512000]
     except (TypeError, ValueError) as e:
         # Handle non-stringifiable objects and non-serializable objects
-        LOGGER.warning("Non-stringifiable object. Error: %s", str(e))
+        LOGGER.warning(f"Non-stringifiable object. Error: {str(e)}")
         return None
 
 

--- a/dbt/adapters/athena/utils.py
+++ b/dbt/adapters/athena/utils.py
@@ -20,7 +20,7 @@ def stringify_table_parameter_value(value: Any) -> str:
             value_str = str(value)
     except (TypeError, ValueError) as e:
         # Handle non-stringifiable objects and non-serializable objects
-        value_str = f"Non-stringifiable object: {type(value)}, Error: {str(e)}"
+        value_str = f"Non-stringifiable object. Error: {str(e)}"
     return value_str[:512000]
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,8 @@
-from dbt.adapters.athena.utils import clean_sql_comment, get_chunks
+from dbt.adapters.athena.utils import (
+    clean_sql_comment,
+    get_chunks,
+    stringify_for_table_property,
+)
 
 
 def test_clean_comment():
@@ -12,6 +16,14 @@ def test_clean_comment():
         )
         == "my long comment on several lines with weird spaces and indents."
     )
+
+
+def test_stringify_for_table_property():
+    assert stringify_for_table_property(True) == "True"
+    assert stringify_for_table_property(123) == "123"
+    assert stringify_for_table_property("dbt-athena") == "dbt-athena"
+    assert stringify_for_table_property(["a", "b", 3]) == '["a", "b", 3]'
+    assert stringify_for_table_property({"a": 1, "b": "c"}) == '{"a": 1, "b": "c"}'
 
 
 def test_get_chunks_empty():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,8 @@
 from dbt.adapters.athena.utils import (
     clean_sql_comment,
     get_chunks,
-    stringify_for_table_property,
+    is_valid_table_parameter_key,
+    stringify_table_parameter_value,
 )
 
 
@@ -18,12 +19,20 @@ def test_clean_comment():
     )
 
 
-def test_stringify_for_table_property():
-    assert stringify_for_table_property(True) == "True"
-    assert stringify_for_table_property(123) == "123"
-    assert stringify_for_table_property("dbt-athena") == "dbt-athena"
-    assert stringify_for_table_property(["a", "b", 3]) == '["a", "b", 3]'
-    assert stringify_for_table_property({"a": 1, "b": "c"}) == '{"a": 1, "b": "c"}'
+def test_stringify_table_parameter_value():
+    assert stringify_table_parameter_value(True) == "True"
+    assert stringify_table_parameter_value(123) == "123"
+    assert stringify_table_parameter_value("dbt-athena") == "dbt-athena"
+    assert stringify_table_parameter_value(["a", "b", 3]) == '["a", "b", 3]'
+    assert stringify_table_parameter_value({"a": 1, "b": "c"}) == '{"a": 1, "b": "c"}'
+    assert len(stringify_table_parameter_value("a" * 512001)) == 512000
+
+
+def test_is_valid_table_parameter_key():
+    assert is_valid_table_parameter_key("valid_key") is True
+    assert is_valid_table_parameter_key("Valid Key 123*!") is True
+    assert is_valid_table_parameter_key("invalid \n key") is False
+    assert is_valid_table_parameter_key("long_key" * 100) is False
 
 
 def test_get_chunks_empty():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,12 +20,25 @@ def test_clean_comment():
 
 
 def test_stringify_table_parameter_value():
+    class NonStringifiableObject:
+        def __str__(self):
+            raise ValueError("Non-stringifiable object")
+
     assert stringify_table_parameter_value(True) == "True"
     assert stringify_table_parameter_value(123) == "123"
     assert stringify_table_parameter_value("dbt-athena") == "dbt-athena"
     assert stringify_table_parameter_value(["a", "b", 3]) == '["a", "b", 3]'
     assert stringify_table_parameter_value({"a": 1, "b": "c"}) == '{"a": 1, "b": "c"}'
     assert len(stringify_table_parameter_value("a" * 512001)) == 512000
+    print(stringify_table_parameter_value(NonStringifiableObject()))
+    assert (
+        stringify_table_parameter_value(NonStringifiableObject())
+        == "Non-stringifiable object. Error: Non-stringifiable object"
+    )
+    assert (
+        stringify_table_parameter_value([NonStringifiableObject()])
+        == "Non-stringifiable object. Error: Object of type NonStringifiableObject is not JSON serializable"
+    )
 
 
 def test_is_valid_table_parameter_key():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -30,15 +30,8 @@ def test_stringify_table_parameter_value():
     assert stringify_table_parameter_value(["a", "b", 3]) == '["a", "b", 3]'
     assert stringify_table_parameter_value({"a": 1, "b": "c"}) == '{"a": 1, "b": "c"}'
     assert len(stringify_table_parameter_value("a" * 512001)) == 512000
-    print(stringify_table_parameter_value(NonStringifiableObject()))
-    assert (
-        stringify_table_parameter_value(NonStringifiableObject())
-        == "Non-stringifiable object. Error: Non-stringifiable object"
-    )
-    assert (
-        stringify_table_parameter_value([NonStringifiableObject()])
-        == "Non-stringifiable object. Error: Object of type NonStringifiableObject is not JSON serializable"
-    )
+    assert stringify_table_parameter_value(NonStringifiableObject()) is None
+    assert stringify_table_parameter_value([NonStringifiableObject()]) is None
 
 
 def test_is_valid_table_parameter_key():


### PR DESCRIPTION
# Description

Hi team, I suggest improvement which should significantly improve data observability from my point of view.

If `persist_docs` is enabled we write additional metadata to Glue Table Properties:

- all fields from `model.config.meta` (i.e. owner, unique_key, other custom fields)
- `model.config.materialized` value (to mark incremental tables)
- dbt project name and version (to identify tables depoyed via dbt and find outdated tables by project version)

This improvement allows to treat Glue Catalog as a storage of tabel metadata and build interactive application around it without need to access dbt manifest.

## Models used to test - Optional
Tested on view, table, incremental table

## Checklist

- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [X] You kept your Pull Request small and focused on a single feature or bug fix.
- [X] You added unit testing when necessary
- [X] You added functional testing when necessary
