### PR TITLE
fix: insert_overwrite updates for tables with int partitions

### DIFF
--- a/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/helpers.sql
@@ -70,7 +70,7 @@
     {%- set single_partition = [] -%}
     {%- for col in row -%}
       {%- set column_type = adapter.convert_type(table, loop.index0) -%}
-      {%- if column_type == 'integer' -%}
+      {%- if column_type == 'integer' or column_type is none -%}
         {%- set value = col|string -%}
       {%- elif column_type == 'string' -%}
         {%- set value = "'" + col + "'" -%}


### PR DESCRIPTION
# Description

Fix incremental updates for tables with the `insert_overwrite` strategy and `int` partition columns when using dbt-core==1.6.3. Otherwise updates fail with:
```
  can only concatenate str (not "NoneType") to str
  
  > in macro materialization_incremental_athena (macros/materializations/models/incremental/incremental.sql)
  > called by ...
```

The root cause is exactly as in https://github.com/dbt-athena/dbt-athena/pull/425 (`convert_type()` returns None for int columns)
This PR adds the same workaround to `delete_overlapping_partitions()`. 

## Models used to test - Optional

```sql
{{
	config(
		materialized = 'incremental',
		incremental_strategy = 'insert_overwrite',
		partitioned_by = ['m']
	)
}}

select 'val' as val, 1 as m
```

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
