### PR TITLE
fix(docs): generate docs for Federated Data Sources with capitalized table names

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -563,7 +563,7 @@ class AthenaAdapter(SQLAdapter):
                     MaxResults=50,  # Limit supported by this operation
                 ):
                     for table in page["TableMetadataList"]:
-                        if relations and table["Name"] in relations:
+                        if relations and table["Name"].lower() in relations:
                             catalog.extend(
                                 self._get_one_table_for_non_glue_catalog(
                                     table, schema, information_schema.path.database


### PR DESCRIPTION
# Description

Currently it is impossible to successfully run dbt docs generate if you referencing table with CAPITALIZED NAME from external Data Catalog as a dbt source.
This because under the hood boto3 returns original table name, but source name are being converted to lower case somewhere in dbt core.

## Checklist

- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [X] You kept your Pull Request small and focused on a single feature or bug fix.
- [X] You added unit testing when necessary
- [X] You added functional testing when necessary
