### PR TITLE
feat: allow aws session token in profiles file

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -53,6 +53,7 @@ class AthenaCredentials(Credentials):
     aws_profile_name: Optional[str] = None
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None
+    aws_session_token: Optional[str] = None
     poll_interval: float = 1.0
     debug_query_state: bool = False
     _ALIASES = {"catalog": "database"}
@@ -84,6 +85,7 @@ class AthenaCredentials(Credentials):
             "aws_profile_name",
             "aws_access_key_id",
             "aws_secret_access_key",
+            "aws_session_token",
             "endpoint_url",
             "s3_data_dir",
             "s3_data_naming",

--- a/dbt/adapters/athena/session.py
+++ b/dbt/adapters/athena/session.py
@@ -7,6 +7,7 @@ def get_boto3_session(connection: Connection) -> boto3.session.Session:
     return boto3.session.Session(
         aws_access_key_id=connection.credentials.aws_access_key_id,
         aws_secret_access_key=connection.credentials.aws_secret_access_key,
+        aws_session_token=connection.credentials.aws_session_token,
         region_name=connection.credentials.region_name,
         profile_name=connection.credentials.aws_profile_name,
     )


### PR DESCRIPTION
# Description
Resolves https://github.com/dbt-athena/dbt-athena/issues/458

This PR adds support for passing in the AWS session token to a profiles.yml file, allowing for the use of short term credentials.

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
