### PR TITLE
fix: add 'CatalogId' Parameter to Glue Paginator Call (Related to PR #370)

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -335,10 +335,14 @@ class AthenaAdapter(SQLAdapter):
         conn = self.connections.get_thread_connection()
         client = conn.handle
 
+        data_catalog = self._get_data_catalog(relation.database)
+        catalog_id = get_catalog_id(data_catalog)
+
         with boto3_client_lock:
             glue_client = client.session.client("glue", region_name=client.region_name, config=get_boto3_config())
         paginator = glue_client.get_paginator("get_partitions")
         partition_params = {
+            "CatalogId": catalog_id,
             "DatabaseName": relation.schema,
             "TableName": relation.identifier,
             "Expression": where_condition,

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -509,6 +509,7 @@ class TestAthenaAdapter:
     @mock_glue
     @mock_s3
     @mock_athena
+    @mock_sts
     def test_clean_up_partitions_will_work(self, dbt_debug_caplog, mock_aws_service):
         table_name = "table"
         mock_aws_service.create_data_catalog()


### PR DESCRIPTION
# Description

Added 'CatalogId' Parameter to the Glue Paginator Call

This PR adds the 'CatalogId' parameter to the Glue Paginator Call. It is related to the changes made in PR #370, which has already been merged.

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
