### PR TITLE
fix: bug when setting pre-hook=MSCK REPAIR TABLE

### DIFF
--- a/dbt/adapters/athena/query_headers.py
+++ b/dbt/adapters/athena/query_headers.py
@@ -16,7 +16,7 @@ class _QueryComment(dbt.adapters.base.query_headers._QueryComment):
 
         # alter or vacuum statements don't seem to support properly query comments
         # let's just exclude them
-        if any(map(sql.lower().__contains__, ["alter", "drop", "optimize", "vacuum"])):
+        if any(map(sql.lower().__contains__, ["alter", "drop", "optimize", "vacuum", "msck"])):
             return sql
 
         cleaned_query_comment = self.query_comment.strip().replace("\n", " ")

--- a/tests/unit/test_query_headers.py
+++ b/tests/unit/test_query_headers.py
@@ -68,3 +68,9 @@ class TestQueryHeaders:
         self.query_header.comment.append = True
         sql = "VACUUM table"
         assert self.query_header.add(sql) == sql
+
+    def test_no_query_comment_on_msck(self):
+        self.query_header.comment.query_comment = "executed by dbt"
+        self.query_header.comment.append = True
+        sql = "MSCK REPAIR TABLE"
+        assert self.query_header.add(sql) == sql


### PR DESCRIPTION
Fix MSCK REPAIR TABLE.

# Description

Fix when setting pre-hook: `MSCK REPAIR TABLE`, but got error as bellow:
[ErrorCategory:USER_ERROR, ErrorCode:DDL_FAILED], Detail:FAILED: ParseException line 1:216 cannot recognize input near '<EOF>' '<EOF>' '<EOF>'

Resolve #468 

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [ ] You added functional testing when necessary
