### PR TITLE
feat: Implement insert condition for merge strategy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,8 +385,9 @@ It is possible to use Iceberg in an incremental fashion, specifically two strate
     be useful for improving performance via predicate pushdown on the target table.
   * `delete_condition` (optional): SQL condition used to identify records that should be deleted.
   * `update_condition` (optional): SQL condition used to identify records that should be updated.
-    * `incremental_predicates`, `delete_condition` and `update_condition` can include any column of the incremental
-      table (`src`) or the final table (`target`).
+  * `insert_condition` (optional): SQL condition used to identify records that should be inserted.
+    * `incremental_predicates`, `delete_condition`, `update_condition` and `insert_condition` can include any column of
+      the incremental table (`src`) or the final table (`target`).
       Column names must be prefixed by either `src` or `target` to prevent a `Column is ambiguous` error.
 
 `delete_condition` example:
@@ -442,6 +443,26 @@ select * from (
 ) as t (id, value)
 
 {% endif %}
+```
+
+`insert_condition` example:
+
+```sql
+{{ config(
+        materialized='incremental',
+        incremental_strategy='merge',
+        unique_key=['id'],
+        insert_condition='target.status != 0',
+        schema='sandbox'
+    )
+}}
+
+select * from (
+    values
+    (1, 0)
+    , (2, 1)
+) as t (id, status)
+
 ```
 
 ### Highly available table (HA)

--- a/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -53,6 +53,7 @@
     {% set incremental_predicates = config.get('incremental_predicates') %}
     {% set delete_condition = config.get('delete_condition') %}
     {% set update_condition = config.get('update_condition') %}
+    {% set insert_condition = config.get('insert_condition') %}
     {% set empty_unique_key -%}
       Merge strategy must implement unique_key as a single column or a list of columns.
     {%- endset %}
@@ -81,6 +82,7 @@
         existing_relation=existing_relation,
         delete_condition=delete_condition,
         update_condition=update_condition,
+        insert_condition=insert_condition,
       )
     %}
     {% do to_drop.append(tmp_relation) %}

--- a/dbt/include/athena/macros/materializations/models/incremental/merge.sql
+++ b/dbt/include/athena/macros/materializations/models/incremental/merge.sql
@@ -56,6 +56,7 @@
     existing_relation,
     delete_condition,
     update_condition,
+    insert_condition,
     statement_name="main"
   )
 %}
@@ -118,7 +119,7 @@
               {%- endif -%}
             {%- endfor %}
       {%- endif %}
-      when not matched
+      when not matched {% if insert_condition is not none -%} and {{ insert_condition }} {%- endif %}
         then insert ({{ dest_cols_csv }})
          values ({{ src_cols_csv }})
     {%- endset -%}


### PR DESCRIPTION
# Description

- This PR introduces insert condition for the merge strategy in the incremental run.
- Resolves [#466  ](https://github.com/dbt-athena/dbt-athena/issues/466)

## Models used to test

```
{{ config(
        table_type='iceberg',
        materialized='incremental',
        incremental_strategy='merge',
        unique_key=['id'],
        insert_condition='src.status != 0'
    )
}}

{% if is_incremental() %}

select * from (
    values
    (1, -1)
    , (2, 0)
    , (3, 1)
) as t (id, status)

{% else %}

select * from (
    values
    (0, 1)
) as t (id, status)

{% endif %}
```

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
- [x] Update documentation ([PR](https://github.com/dbt-athena/dbt-athena.github.io/pull/17))
