### PR TITLE
fix(ci): make flake 8 working in the pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - uses: pre-commit/action@v3.0.0
 
   unit_test:


### PR DESCRIPTION
# Description

Force python version for pre-commits to python 3.11. Locally the pre-commit works for me, and the last merged PR used python 3.11.


## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
