### PR TITLE
fix: change default table_type in cast_timestamp macro

### DIFF
--- a/dbt/include/athena/macros/utils/timestamps.sql
+++ b/dbt/include/athena/macros/utils/timestamps.sql
@@ -9,7 +9,7 @@
 
 {% macro cast_timestamp(timestamp_col) -%}
   {%- set config = model.get('config', {}) -%}
-  {%- set table_type = config.get('table_type', 'glue') -%}
+  {%- set table_type = config.get('table_type', 'hive') -%}
   {%- set is_view = config.get('materialized', 'table') in ['view', 'ephemeral'] -%}
   {%- if table_type == 'iceberg' and not is_view -%}
     cast({{ timestamp_col }} as timestamp(6))


### PR DESCRIPTION
# Description
We have a  table_type glue. But only table type: hive and iceberg are supported.


## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
