### PR TITLE
fix: remove seed_s3_upload_args

### DIFF
--- a/dbt/include/athena/profile_template.yml
+++ b/dbt/include/athena/profile_template.yml
@@ -17,9 +17,6 @@ prompts:
     hint: Specify the database (Data catalog) to build models into (lowercase only)
     default: awsdatacatalog
 
-  seed_s3_upload_args:
-    hint: Specify any extra arguments to use in the S3 Upload, e.g. ACL, SSEKMSKeyId
-
   threads:
     hint: '1 or more'
     type: 'int'


### PR DESCRIPTION
# Description
Adding a prompts in profile_template force the user to add the parameter, even if it's optional.
As we don't have a real default value for seed_s3_upload_args, we can simply remove it.

Closes https://github.com/dbt-athena/dbt-athena/issues/486


## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
