### PR TITLE
chore: use region for concurrency functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -13,9 +13,6 @@ jobs:
     name: Functional Tests - PR
     if: contains(github.event.pull_request.labels.*.name, 'enable-functional-tests')
     uses: ./.github/workflows/functional-tests-workflow.yml
-    concurrency:
-      # global functional tests control to avoid to run more than 1 workflow at the same time across different PRs
-      group: functional_tests_pr
     secrets: inherit
     strategy:
       matrix:
@@ -29,14 +26,15 @@ jobs:
       # this allows to work on fork
       checkout-repository: ${{ github.event.pull_request.head.repo.full_name }}
       aws-region: ${{ matrix.aws-region }}
+      concurrency:
+        # global functional tests control to avoid to run more than 1 workflow at the same time across different PRs
+        group: functional_tests_pr_${{ matrix.aws-region }}
 
   # workflow that is invoked when a push to main happens
   functional-tests-main:
     name: Functional Tests - main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/functional-tests-workflow.yml
-    concurrency:
-      group: functional_tests_main
     secrets: inherit
     strategy:
       matrix:
@@ -48,3 +46,5 @@ jobs:
       checkout-ref: ${{ github.ref }}
       checkout-repository: ${{ github.repository }}
       aws-region: ${{ matrix.aws-region }}
+      concurrency:
+        group: functional_tests_main_${{ matrix.aws-region }}

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -28,7 +28,7 @@ jobs:
       aws-region: ${{ matrix.aws-region }}
       concurrency:
         # functional tests control to avoid to run more than 1 workflow at the same time across different PRs
-        # functional tests can run in parallel for the same region
+        # functional tests can run in parallel for different regions
         group: functional_tests_pr_${{ matrix.aws-region }}
 
   # workflow that is invoked when a push to main happens

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -27,7 +27,8 @@ jobs:
       checkout-repository: ${{ github.event.pull_request.head.repo.full_name }}
       aws-region: ${{ matrix.aws-region }}
       concurrency:
-        # global functional tests control to avoid to run more than 1 workflow at the same time across different PRs
+        # functional tests control to avoid to run more than 1 workflow at the same time across different PRs
+        # functional tests can run in parallel for the same region
         group: functional_tests_pr_${{ matrix.aws-region }}
 
   # workflow that is invoked when a push to main happens


### PR DESCRIPTION
# Description

Use region as a variable for concurrency in our functional tests. The limitations are per region not per account.


## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
