### PR TITLE
fix: prune old versions also for views

### DIFF
--- a/dbt/include/athena/macros/materializations/models/view/view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/view.sql
@@ -1,5 +1,14 @@
 {% materialization view, adapter='athena' -%}
+    {%- set identifier = model['alias'] -%}
+    {%- set versions_to_keep = config.get('versions_to_keep', default=4) -%}
+    {%- set target_relation = api.Relation.create(identifier=identifier,
+                                                schema=schema,
+                                                database=database,
+                                                type='view') -%}
+
     {% set to_return = create_or_replace_view(run_outside_transaction_hooks=False) %}
+
+    {% do adapter.expire_glue_table_versions(target_relation, versions_to_keep, True) %}
 
     {% set target_relation = this.incorporate(type='view') %}
     {% do persist_docs(target_relation, model) %}


### PR DESCRIPTION
# Description

In our dbt runs we received the following error:
```
Number of TABLE_VERSION resources exceeds the account limit 1000000
```

Debugging led to the conclusion that views are creating new versions but old views are not cleaned up.

## Models used to test - Optional
- internal views that had lots of versions, after `dbt run` with this change they are down to last 4 glue versions

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
