### PR TITLE
fix: Null as comment in columns after change in yml

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1012,7 +1012,7 @@ class AthenaAdapter(SQLAdapter):
                     clean_col_comment = ellipsis_comment(clean_sql_comment(col_comment))
                     # Get current column comment from Glue
                     glue_col_comment = col_obj.get("Comment", "")
-                    # Check that meta column description is already attached to Glue table
+                    # Check that column description is already attached to Glue table
                     if glue_col_comment != clean_col_comment:
                         need_to_update_table = True
                     # Save column description from dbt

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1013,8 +1013,8 @@ class AthenaAdapter(SQLAdapter):
                     glue_col_comment = col_obj.get("Comment", "")
                     # Update column description if it's different
                     if glue_col_comment != clean_col_comment:
-                        col_obj["Comment"] = clean_col_comment
                         need_to_update_table = True
+                    col_obj["Comment"] = clean_col_comment
 
         # Update Glue Table only if table/column description is modified.
         # It prevents redundant schema version creating after incremental runs.

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -963,15 +963,16 @@ class AthenaAdapter(SQLAdapter):
         if persist_relation_docs:
             # Prepare dbt description
             clean_table_description = ellipsis_comment(clean_sql_comment(model["description"]))
+            table_input["Description"] = clean_table_description
+            table_parameters["comment"] = clean_table_description
             # Get current description from Glue
             glue_table_description = table.get("Description", "")
             # Get current description parameter from Glue
             glue_table_comment = table["Parameters"].get("comment", "")
+
             # Update description if it's different
             if clean_table_description != glue_table_description or clean_table_description != glue_table_comment:
                 need_to_update_table = True
-            table_input["Description"] = clean_table_description
-            table_parameters["comment"] = clean_table_description
 
             # Get dbt model meta if available
             meta: Dict[str, Any] = model.get("config", {}).get("meta", {})
@@ -990,10 +991,11 @@ class AthenaAdapter(SQLAdapter):
                     if meta_value is not None:
                         # Check that meta value is already attached to Glue table
                         current_meta_value: Optional[str] = table_parameters.get(meta_key)
-                        if current_meta_value is None or current_meta_value != meta_value:
-                            # Update Glue table parameter only if needed
-                            need_to_update_table = True
                         table_parameters[meta_key] = meta_value
+
+                        # Update Glue table parameter only if needed
+                        if current_meta_value is None or current_meta_value != meta_value:
+                            need_to_update_table = True
                     else:
                         LOGGER.warning(f"Meta value for key '{meta_key}' is not supported and will be ignored")
                 else:
@@ -1011,10 +1013,11 @@ class AthenaAdapter(SQLAdapter):
                     clean_col_comment = ellipsis_comment(clean_sql_comment(col_comment))
                     # Get current column comment from Glue
                     glue_col_comment = col_obj.get("Comment", "")
+                    col_obj["Comment"] = clean_col_comment
+
                     # Update column description if it's different
                     if glue_col_comment != clean_col_comment:
                         need_to_update_table = True
-                    col_obj["Comment"] = clean_col_comment
 
         # Update Glue Table only if table/column description is modified.
         # It prevents redundant schema version creating after incremental runs.

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -969,9 +969,9 @@ class AthenaAdapter(SQLAdapter):
             glue_table_comment = table["Parameters"].get("comment", "")
             # Update description if it's different
             if clean_table_description != glue_table_description or clean_table_description != glue_table_comment:
-                table_input["Description"] = clean_table_description
-                table_parameters["comment"] = clean_table_description
                 need_to_update_table = True
+            table_input["Description"] = clean_table_description
+            table_parameters["comment"] = clean_table_description
 
             # Get dbt model meta if available
             meta: Dict[str, Any] = model.get("config", {}).get("meta", {})
@@ -992,8 +992,8 @@ class AthenaAdapter(SQLAdapter):
                         current_meta_value: Optional[str] = table_parameters.get(meta_key)
                         if current_meta_value is None or current_meta_value != meta_value:
                             # Update Glue table parameter only if needed
-                            table_parameters[meta_key] = meta_value
                             need_to_update_table = True
+                        table_parameters[meta_key] = meta_value
                     else:
                         LOGGER.warning(f"Meta value for key '{meta_key}' is not supported and will be ignored")
                 else:


### PR DESCRIPTION
# Description

Fix null as comment in columns after change in yml

Now, after changing a comment on a column, the comment is left only for the changed column.
Comments on other columns will be marked as null.
This situation has been fixed.

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
