### PR TITLE
add possibility to set external_location for incremental model on iceberg table

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/athena/macros/materializations/models/table/create_table_as.sql
@@ -42,7 +42,7 @@
       {%- set bucket_count = none -%}
       {% do log(ignored_bucket_iceberg) %}
     {%- endif -%}
-    {%- if 'unique' not in s3_data_naming or external_location is not none -%}
+    {%- if materialization=table and (if 'unique' not in s3_data_naming or external_location is not none) -%}
       {%- set error_unique_location_iceberg -%}
         You need to have an unique table location when creating Iceberg table since we use the RENAME feature
         to have near-zero downtime.


### PR DESCRIPTION
# Description

Add possibility to set `external_location` for incremental model on iceberg table.
So in this way we can avoid to use uuid on table path and use a naming convention on Data Lake , apply Data Governance rules, better organize the Data Lake.

#559 

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
