### PR TITLE
fix: backup table would be deleted, even if it doesnt exist

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -10,6 +10,9 @@
   {%- set old_tmp_relation = adapter.get_relation(identifier=identifier ~ '__ha',
                                              schema=schema,
                                              database=database) -%}
+  {%- set old_bkp_relation = adapter.get_relation(identifier=identifier ~ '__bkp',
+                                             schema=schema,
+                                             database=database) -%}
   {%- set is_ha = config.get('ha', default=false) -%}
   {%- set s3_data_dir = config.get('s3_data_dir', default=target.s3_data_dir) -%}
   {%- set s3_data_naming = config.get('s3_data_naming', default='table_unique') -%}
@@ -92,8 +95,8 @@
         -- afterwards, therefore we are in weird state. The easiest and cleanest should be to remove
         -- the backup relation. It won't have an impact because since we are in the else condition,
         -- that means that old relation exists therefore no downtime yet.
-        {%- if old_relation_bkp is not none -%}
-          {%- do drop_relation(old_relation_bkp) -%}
+        {%- if old_bkp_relation is not none -%}
+          {%- do drop_relation(old_bkp_relation) -%}
         {%- endif -%}
 
         {% set query_result = safe_create_table_as(False, tmp_relation, sql, force_batch) %}


### PR DESCRIPTION
# Description

Similar to my previous issue with the tmp tables being deleted even if they dont exist. 

We check if the relation locally exists, which is always does, because we just created it.

Instead, we need to check if the backup table in the source system exists. 

very similar changes too: https://github.com/dbt-athena/dbt-athena/pull/550

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [X] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
