### PR TITLE
fix: remove lf_inherited_tags parameter from create_or_replace_view macros

### DIFF
--- a/dbt/include/athena/macros/materializations/models/view/create_or_replace_view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/create_or_replace_view.sql
@@ -33,7 +33,7 @@
   {%- endcall %}
 
   {% if lf_tags_config is not none %}
-    {{ adapter.add_lf_tags(target_relation, lf_tags_config, lf_inherited_tags) }}
+    {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
   {% endif %}
 
   {% if lf_grants is not none %}

--- a/dbt/include/athena/macros/materializations/models/view/view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/view.sql
@@ -1,6 +1,7 @@
 {% materialization view, adapter='athena' -%}
     {%- set identifier = model['alias'] -%}
     {%- set lf_tags_config = config.get('lf_tags_config') -%}
+    {%- set lf_inherited_tags = config.get('lf_inherited_tags') -%}
     {%- set lf_grants = config.get('lf_grants') -%}
     {%- set versions_to_keep = config.get('versions_to_keep', default=4) -%}
     {%- set target_relation = api.Relation.create(identifier=identifier,
@@ -15,7 +16,7 @@
     {% set target_relation = this.incorporate(type='view') %}
 
     {% if lf_tags_config is not none %}
-      {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
+      {{ adapter.add_lf_tags(target_relation, lf_tags_config, lf_inherited_tags) }}
     {% endif %}
 
     {% if lf_grants is not none %}

--- a/dbt/include/athena/macros/materializations/models/view/view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/view.sql
@@ -11,7 +11,6 @@
     {% do adapter.expire_glue_table_versions(target_relation, versions_to_keep, False) %}
 
     {% set target_relation = this.incorporate(type='view') %}
-
     {% do persist_docs(target_relation, model) %}
 
     {% do return(to_return) %}

--- a/dbt/include/athena/macros/materializations/models/view/view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/view.sql
@@ -1,10 +1,5 @@
 {% materialization view, adapter='athena' -%}
     {%- set identifier = model['alias'] -%}
-
-    {%- set lf_tags_config = config.get('lf_tags_config') -%}
-    {%- set lf_inherited_tags = config.get('lf_inherited_tags') -%}
-    {%- set lf_grants = config.get('lf_grants') -%}
-
     {%- set versions_to_keep = config.get('versions_to_keep', default=4) -%}
     {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
@@ -14,14 +9,6 @@
     {% set to_return = create_or_replace_view(run_outside_transaction_hooks=False) %}
 
     {% do adapter.expire_glue_table_versions(target_relation, versions_to_keep, False) %}
-
-    {% if lf_tags_config is not none %}
-      {{ adapter.add_lf_tags(target_relation, lf_tags_config, lf_inherited_tags) }}
-    {% endif %}
-
-    {% if lf_grants is not none %}
-      {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
-    {% endif %}
 
     {% set target_relation = this.incorporate(type='view') %}
 

--- a/dbt/include/athena/macros/materializations/models/view/view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/view.sql
@@ -1,8 +1,10 @@
 {% materialization view, adapter='athena' -%}
     {%- set identifier = model['alias'] -%}
+
     {%- set lf_tags_config = config.get('lf_tags_config') -%}
     {%- set lf_inherited_tags = config.get('lf_inherited_tags') -%}
     {%- set lf_grants = config.get('lf_grants') -%}
+
     {%- set versions_to_keep = config.get('versions_to_keep', default=4) -%}
     {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
@@ -13,8 +15,6 @@
 
     {% do adapter.expire_glue_table_versions(target_relation, versions_to_keep, False) %}
 
-    {% set target_relation = this.incorporate(type='view') %}
-
     {% if lf_tags_config is not none %}
       {{ adapter.add_lf_tags(target_relation, lf_tags_config, lf_inherited_tags) }}
     {% endif %}
@@ -22,6 +22,8 @@
     {% if lf_grants is not none %}
       {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
     {% endif %}
+
+    {% set target_relation = this.incorporate(type='view') %}
 
     {% do persist_docs(target_relation, model) %}
 

--- a/dbt/include/athena/macros/materializations/models/view/view.sql
+++ b/dbt/include/athena/macros/materializations/models/view/view.sql
@@ -1,5 +1,7 @@
 {% materialization view, adapter='athena' -%}
     {%- set identifier = model['alias'] -%}
+    {%- set lf_tags_config = config.get('lf_tags_config') -%}
+    {%- set lf_grants = config.get('lf_grants') -%}
     {%- set versions_to_keep = config.get('versions_to_keep', default=4) -%}
     {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
@@ -11,6 +13,15 @@
     {% do adapter.expire_glue_table_versions(target_relation, versions_to_keep, False) %}
 
     {% set target_relation = this.incorporate(type='view') %}
+
+    {% if lf_tags_config is not none %}
+      {{ adapter.add_lf_tags(target_relation, lf_tags_config) }}
+    {% endif %}
+
+    {% if lf_grants is not none %}
+      {{ adapter.apply_lf_grants(target_relation, lf_grants) }}
+    {% endif %}
+
     {% do persist_docs(target_relation, model) %}
 
     {% do return(to_return) %}


### PR DESCRIPTION
# Description
Resolves #564
During fix in #487 wasn't removed lf_inhered_tags parameter from create_or_replace_view.sql macros, that's why I get error when create view.

## Models used to test - Optional
Described in #564 

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
