### PR TITLE
fix: duplication of hooks in incremental materialization

### DIFF
--- a/dbt/include/athena/macros/materializations/hooks.sql
+++ b/dbt/include/athena/macros/materializations/hooks.sql
@@ -1,6 +1,6 @@
 {% macro run_hooks(hooks, inside_transaction=True) %}
   {% set re = modules.re %}
-  {% for hook in hooks %}
+  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction) %}
     {% set rendered = render(hook.get('sql')) | trim %}
     {% if (rendered | length) > 0 %}
       {%- if re.match("optimize\W+\w+\W+rewrite data using bin_pack", rendered.lower(), re.MULTILINE) -%}


### PR DESCRIPTION
# Description
I found that there is a duplication of running hooks for incremental materialization.
This happens because of run_hooks macro which does not filter hooks list for different modes of inside_transaction:
```
    {{ run_hooks(post_hooks, inside_transaction=True) }}
    {{ run_hooks(post_hooks, inside_transaction=False) }}
```

Test model:
```
{{
    config(
        materialized='incremental',
        incremental_strategy='append',
        post_hook="select 'DEBUG RUN_HOOK' as r",
    )
}}

select 1 as id, cast('2024-01-01' as timestamp(6)) as event_ts;
```
## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
