### PR TITLE
fix: dependency conflict with airflow 2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
     include_package_data=True,
     install_requires=[
         # In order to control dbt-core version and package version
-        "boto3~=1.34",
-        "boto3-stubs[athena,glue,lakeformation,sts]~=1.34",
+        "boto3~=1.33",
+        "boto3-stubs[athena,glue,lakeformation,sts]~=1.33",
         "dbt-core~=1.7.0",
         "mmh3>=4.0.1,<4.2.0",
         "pyathena>=2.25,<4.0",


### PR DESCRIPTION
# Description

- Downgrade boto3 & boto3-stubs to 1.33 to be compatible with Airflow 2.8
- `1.7.1` was compatible with Airflow 2.7 & 2.8

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
