### PR TITLE
fix: downgrade boto3 for airflow 2.7 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
     include_package_data=True,
     install_requires=[
         # In order to control dbt-core version and package version
-        "boto3~=1.34",
-        "boto3-stubs[athena,glue,lakeformation,sts]~=1.34",
+        "boto3~=1.33",
+        "boto3-stubs[athena,glue,lakeformation,sts]~=1.33",
         "dbt-core~=1.7.0",
         "mmh3>=4.0.1,<4.2.0",
         "pyathena>=2.25,<4.0",

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
     include_package_data=True,
     install_requires=[
         # In order to control dbt-core version and package version
-        "boto3~=1.33",
-        "boto3-stubs[athena,glue,lakeformation,sts]~=1.33",
+        "boto3>=1.28",
+        "boto3-stubs[athena,glue,lakeformation,sts]>=1.28",
         "dbt-core~=1.7.0",
         "mmh3>=4.0.1,<4.2.0",
         "pyathena>=2.25,<4.0",


### PR DESCRIPTION
# Description

- To enable compatibility with airflow 2.7, we would need to go down to 1.28
This might be the preferred solution, as this compatibility matrix suggests dbt-core~=1.7 is compatible with airflow~=2.7
https://astronomer.github.io/astronomer-cosmos/getting_started/execution-modes-local-conflicts.html#airflow-and-dbt-dependencies-conflicts

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
