### PR TITLE
feat: remove partition schema when incremental model overwrites partitions

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -407,6 +407,12 @@ class AthenaAdapter(SQLAdapter):
         partitions = partition_pg.build_full_result().get("Partitions")
         for partition in partitions:
             self.delete_from_s3(partition["StorageDescriptor"]["Location"])
+            glue_client.delete_partition(
+                CatalogId=catalog_id,
+                DatabaseName=relation.schema,
+                TableName=relation.identifier,
+                PartitionValues=partition["Values"],
+            )
 
     @available
     def clean_up_table(self, relation: AthenaRelation) -> None:


### PR DESCRIPTION
# Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

Glue has two kinds of schema, table schema and partition schema.
When the table schema is updated, the partition schema does not follow it automatically.
This causes [`HIVE_PARTITION_SCHEMA_MISMATCH`](https://repost.aws/knowledge-center/athena-hive-partition-schema-mismatch) in some conditions.

To avoid this, `clean_up_partitions` is modified to delete partition schemas as well as delete s3 objects.

I also found getting `Parameters` of `table` shows KeyError on some tables.
To fix it, I use `get` statement on `table`


## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
