### PR TITLE
fix: Optimize regex in post-hooks

### DIFF
--- a/dbt/include/athena/macros/materializations/hooks.sql
+++ b/dbt/include/athena/macros/materializations/hooks.sql
@@ -3,7 +3,7 @@
   {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction) %}
     {% set rendered = render(hook.get('sql')) | trim %}
     {% if (rendered | length) > 0 %}
-      {%- if re.match("optimize\W+\w+\W+rewrite data using bin_pack", rendered.lower(), re.MULTILINE) -%}
+      {%- if re.match("optimize\W+\S+\W+rewrite data using bin_pack", rendered.lower(), re.MULTILINE) -%}
         {%- do adapter.run_optimize_with_partition_limit_catching(rendered) -%}
       {%- else -%}
         {% call statement(auto_begin=inside_transaction) %}


### PR DESCRIPTION
`optimize\W+\w+\W+rewrite data using bin_pack` does not match `optimize awsdatacatalog.db_name.fct_table_name__inc rewrite data using bin_pack` and therefor fails.

# Description

I was wondering why this does not work. But the current regex does not match <data_source>.<db_name>.<table_name>.

Can you maybe check on your end, why the regex was designed this way? Not too sure if I am missing sth.
My post hooks are:

```
    ...
    s3_data_naming = 'schema_table_unique',
    post_hook=['optimize {{ this }} rewrite data using bin_pack', 'vacuum {{ this }}'],
    table_properties={
     'optimize_rewrite_delete_file_threshold': '10'
     }
  )
```

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
