### PR TITLE
fix: allow release to be beta

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ def _get_plugin_version_dict() -> Dict[str, Any]:
 
 def _get_package_version() -> str:
     parts = _get_plugin_version_dict()
-    return f'{parts["major"]}.{parts["minor"]}.{parts["patch"]}'
+    version = "{major}.{minor}.{patch}".format(**parts)
+    if parts["prekind"] and parts["pre"]:
+        version += parts["prekind"] + parts["pre"]
+    return version
 
 
 description = "The athena adapter plugin for dbt (data build tool)"


### PR DESCRIPTION
# Description
The current function in setup.py didn't allow to publish semnatic versions with prekind and pre. This of course affected the release of the the adapter for the beta release, consequently the published library was 1.8.0, that is actually not correct.

This PR fix the parsing, purely take from https://github.com/starburstdata/dbt-trino/blob/master/setup.py#L45-L50


## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
