### PR TITLE
fix: allow switch from hive to iceberg table

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -116,7 +116,6 @@
           {%- do drop_relation(old_tmp_relation) -%}
         {%- endif -%}
 
-        {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
         -- If we have this, it means that at least the first renaming occurred but there was an issue
         -- afterwards, therefore we are in weird state. The easiest and cleanest should be to remove
         -- the backup relation. It won't have an impact because since we are in the else condition,
@@ -136,14 +135,18 @@
         {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation) -%}
 
         {%- if old_relation_table_type == 'iceberg' -%}
-          {{ rename_relation(old_relation, old_relation_bkp) }}
+          {{ rename_relation(old_relation, old_bkp_relation) }}
         {%- else  -%}
           {%- do drop_relation_glue(old_relation) -%}
         {%- endif -%}
 
         {{ rename_relation(tmp_relation, target_relation) }}
 
-        {{ drop_relation(old_relation_bkp) }}
+        -- old_bkp_relation might not exists in case we have a switch from hive to iceberg
+        -- we prevent to drop something that doesn't exist even if drop_relation is able to deal with not existing tables
+        {%- if old_bkp_relation is not none -%}
+          {%- do drop_relation(old_bkp_relation) -%}
+        {%- endif -%}
       {%- endif -%}
     {%- endif -%}
 

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -132,7 +132,15 @@
             {{ query_result }}
           {% endcall %}
         {%- endif -%}
-        {{ rename_relation(old_relation, old_relation_bkp) }}
+
+        {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation) -%}
+
+        {%- if old_relation_table_type == 'iceberg' -%}
+          {{ rename_relation(old_relation, old_relation_bkp) }}
+        {%- else  -%}
+          {%- do drop_relation_glue(old_relation) -%}
+        {%- endif -%}
+
         {{ rename_relation(tmp_relation, target_relation) }}
 
         {{ drop_relation(old_relation_bkp) }}

--- a/tests/functional/adapter/test_hive_iceberg.py
+++ b/tests/functional/adapter/test_hive_iceberg.py
@@ -13,11 +13,13 @@ models__table_base_model = """
 
 select
     1 as id,
-    'test 1' as name
+    'test 1' as name,
+    {{ cast_timestamp('current_timestamp') }} as created_at
 union all
 select
     2 as id,
-    'test 2' as name
+    'test 2' as name,
+    {{ cast_timestamp('current_timestamp') }} as created_at
 """
 
 

--- a/tests/functional/adapter/test_hive_iceberg.py
+++ b/tests/functional/adapter/test_hive_iceberg.py
@@ -1,0 +1,65 @@
+import pytest
+
+from dbt.contracts.results import RunStatus
+from dbt.tests.util import run_dbt
+
+models__table_base_model = """
+{{ config(
+        materialized='table',
+        table_type=var("table_type"),
+        s3_data_naming='table_unique'
+    )
+}}
+
+select
+    1 as id,
+    'test 1' as name
+union all
+select
+    2 as id,
+    'test 2' as name
+"""
+
+
+class TestTableFromHiveToIceberg:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"table_hive_to_iceberg.sql": models__table_base_model}
+
+    def test__table_creation(self, project):
+        relation_name = "table_hive_to_iceberg"
+        model_run_result_row_count_query = f"select count(*) as records from {project.test_schema}.{relation_name}"
+
+        model_run_hive = run_dbt(["run", "--select", relation_name, "--vars", '{"table_type":"hive"}'])
+        model_run_result_hive = model_run_hive.results[0]
+        assert model_run_result_hive.status == RunStatus.Success
+        models_records_count_hive = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
+        assert models_records_count_hive == 2
+
+        model_run_iceberg = run_dbt(["run", "--select", relation_name, "--vars", '{"table_type":"iceberg"}'])
+        model_run_result_iceberg = model_run_iceberg.results[0]
+        assert model_run_result_iceberg.status == RunStatus.Success
+        models_records_count_iceberg = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
+        assert models_records_count_iceberg == 2
+
+
+class TestTableFromIcebergToHive:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"table_iceberg_to_hive.sql": models__table_base_model}
+
+    def test__table_creation(self, project):
+        relation_name = "table_iceberg_to_hive"
+        model_run_result_row_count_query = f"select count(*) as records from {project.test_schema}.{relation_name}"
+
+        model_run_iceberg = run_dbt(["run", "--select", relation_name, "--vars", '{"table_type":"iceberg"}'])
+        model_run_result_iceberg = model_run_iceberg.results[0]
+        assert model_run_result_iceberg.status == RunStatus.Success
+        models_records_count_iceberg = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
+        assert models_records_count_iceberg == 2
+
+        model_run_hive = run_dbt(["run", "--select", relation_name, "--vars", '{"table_type":"hive"}'])
+        model_run_result_hive = model_run_hive.results[0]
+        assert model_run_result_hive.status == RunStatus.Success
+        models_records_count_hive = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
+        assert models_records_count_hive == 2


### PR DESCRIPTION
# Description

Fixes https://github.com/dbt-athena/dbt-athena/issues/478

Also add functional tests to be sure that we can switch smoothly from hive to iceberg, and from iceberg to hive.
This can be really helpfull, to allow users to change table type easily without a full-refresh.

For the functional tests I did a sort of hack, where I pass the table_type via a `table_type` var, that then it's used in the config like this: `table_type=var("table_type"),` works fine.

## Models used to test - Optional
Provided functional tests to cover the implementation

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
