### PR TITLE
fix: avoid deleting S3 location because listing relations continues on error

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -695,14 +695,14 @@ class AthenaAdapter(SQLAdapter):
                 config=get_boto3_config(num_retries=creds.effective_num_retries),
             )
 
-        catalog_id = get_catalog_id(data_catalog)
+        kwargs = {
+            "DatabaseName": schema_relation.schema,
+        }
+        if catalog_id := get_catalog_id(data_catalog):
+            kwargs["CatalogId"] = catalog_id
         paginator = glue_client.get_paginator("get_tables")
         try:
-            tables = (
-                paginator.paginate(DatabaseName=schema_relation.schema, CatalogId=catalog_id)
-                .build_full_result()
-                .get("TableList")
-            )
+            tables = paginator.paginate(**kwargs).build_full_result().get("TableList")
         except ClientError as e:
             # don't error out when schema doesn't exist
             # this allows dbt to create and manage schemas/databases

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -694,48 +694,47 @@ class AthenaAdapter(SQLAdapter):
                 region_name=client.region_name,
                 config=get_boto3_config(num_retries=creds.effective_num_retries),
             )
+
+        catalog_id = get_catalog_id(data_catalog)
         paginator = glue_client.get_paginator("get_tables")
-
-        kwargs = {
-            "DatabaseName": schema_relation.schema,
-        }
-        # If the catalog is `awsdatacatalog` we don't need to pass CatalogId as boto3 infers it from the account Id.
-        if catalog_id := get_catalog_id(data_catalog):
-            kwargs["CatalogId"] = catalog_id
-        page_iterator = paginator.paginate(**kwargs)
-
-        relations = []
-        quote_policy = {"database": True, "schema": True, "identifier": True}
-
         try:
-            for page in page_iterator:
-                tables = page["TableList"]
-                for table in tables:
-                    if "TableType" not in table:
-                        LOGGER.debug(f"Table '{table['Name']}' has no TableType attribute - Ignoring")
-                        continue
-                    _type = table["TableType"]
-                    _detailed_table_type = table.get("Parameters", {}).get("table_type", "")
-                    if _type == "VIRTUAL_VIEW":
-                        _type = self.Relation.View
-                    else:
-                        _type = self.Relation.Table
-
-                    relations.append(
-                        self.Relation.create(
-                            schema=schema_relation.schema,
-                            database=schema_relation.database,
-                            identifier=table["Name"],
-                            quote_policy=quote_policy,
-                            type=_type,
-                            detailed_table_type=_detailed_table_type,
-                        )
-                    )
+            tables = (
+                paginator.paginate(DatabaseName=schema_relation.schema, CatalogId=catalog_id)
+                .build_full_result()
+                .get("TableList")
+            )
         except ClientError as e:
             # don't error out when schema doesn't exist
             # this allows dbt to create and manage schemas/databases
-            LOGGER.debug(f"Schema '{schema_relation.schema}' does not exist - Ignoring: {e}")
+            if e.response["Error"]["Code"] == "EntityNotFoundException":
+                LOGGER.debug(f"Schema '{schema_relation.schema}' does not exist - Ignoring: {e}")
+                return []
+            else:
+                raise e
 
+        relations: list[BaseRelation] = []
+        quote_policy = {"database": True, "schema": True, "identifier": True}
+        for table in tables:
+            if "TableType" not in table:
+                LOGGER.info(f"Table '{table['Name']}' has no TableType attribute - Ignoring")
+                continue
+            _type = table["TableType"]
+            _detailed_table_type = table.get("Parameters", {}).get("table_type", "")
+            if _type == "VIRTUAL_VIEW":
+                _type = self.Relation.View
+            else:
+                _type = self.Relation.Table
+
+            relations.append(
+                self.Relation.create(
+                    schema=schema_relation.schema,
+                    database=schema_relation.database,
+                    identifier=table["Name"],
+                    quote_policy=quote_policy,
+                    type=_type,
+                    detailed_table_type=_detailed_table_type,
+                )
+            )
         return relations
 
     def _get_one_catalog_by_relations(

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -666,6 +666,17 @@ class TestAthenaAdapter:
         self._test_list_relations_without_caching(schema_relation)
 
     @mock_aws
+    def test_list_relations_without_caching_on_unknown_schema(self, mock_aws_service):
+        schema_relation = self.adapter.Relation.create(
+            database=DATA_CATALOG_NAME,
+            schema="unknown_schema",
+            quote_policy=self.adapter.config.quoting,
+        )
+        self.adapter.acquire_connection("dummy")
+        relations = self.adapter.list_relations_without_caching(schema_relation)
+        assert relations == []
+
+    @mock_aws
     @patch("dbt.adapters.athena.impl.SQLAdapter.list_relations_without_caching", return_value=[])
     def test_list_relations_without_caching_with_non_glue_data_catalog(
         self, parent_list_relations_without_caching, mock_aws_service

--- a/tests/unit/test_query_headers.py
+++ b/tests/unit/test_query_headers.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from dbt.adapters.athena.query_headers import AthenaMacroQueryStringSetter
-from dbt.context.manifest import generate_query_header_context
+from dbt.context.query_header import generate_query_header_context
 
 from .constants import AWS_REGION, DATA_CATALOG_NAME, DATABASE_NAME
 from .utils import config_from_parts_or_dicts


### PR DESCRIPTION
# Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

`list_relations_without_caching` continues even when an error occurs when paginating tables.
As a result, this function returns `relations` before collecting all the tables in a Glue database.
To avoid this, build full pagination before collecting tables in the loop.
Also, catch more precise errors about `ClientException`.

- Dissucssion on Slack: https://getdbt.slack.com/archives/C013MLFR7BQ/p1713756253589009

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
