### PR TITLE
feat: prevent secret key and session token from being logged

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -93,8 +93,6 @@ class AthenaCredentials(Credentials):
             "poll_interval",
             "aws_profile_name",
             "aws_access_key_id",
-            "aws_secret_access_key",
-            "aws_session_token",
             "endpoint_url",
             "s3_data_dir",
             "s3_data_naming",


### PR DESCRIPTION
# Description
Currently any fields returned by `_connection_keys` are considered safe to log while debugging. This could lead to these credentials being logged unintentionally. 

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
