### PR TITLE
feat: Add column meta to glue column parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
     - [Iceberg](#iceberg)
     - [Highly available table (HA)](#highly-available-table-ha)
       - [HA Known issues](#ha-known-issues)
+    - [Update glue data catalog](#update-glue-data-catalog)
   - [Snapshots](#snapshots)
     - [Timestamp strategy](#timestamp-strategy)
     - [Check strategy](#check-strategy)
@@ -504,6 +505,32 @@ By default, the materialization keeps the last 4 table versions, you can change 
   In case high performances are needed consider bucketing instead of partitions
 - By default, Glue "duplicates" the versions internally, so the last two versions of a table point to the same location
 - It's recommended to have `versions_to_keep` >= 4, as this will avoid having the older location removed
+
+### Update glue data catalog
+
+Optionally persist resource descriptions as column and relation comments to the glue data catalog, and meta as
+[glue table properties](https://docs.aws.amazon.com/glue/latest/dg/tables-described.html#table-properties)
+and [column parameters](https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html).
+By default, documentation persistence is disabled, but it can be enabled for specific resources or
+groups of resources as needed.
+
+For example:
+
+```yaml
+models:
+  - name: test_deduplicate
+    description: another value
+    config:
+      persist_docs:
+        relation: true
+        columns: true
+      meta: {'test':'value'}
+    columns:
+      - name: id
+        meta: {'primary_key': 'true'}
+```
+
+See [persist docs](https://docs.getdbt.com/reference/resource-configs/persist_docs) for more details.
 
 ## Snapshots
 

--- a/README.md
+++ b/README.md
@@ -524,10 +524,12 @@ models:
       persist_docs:
         relation: true
         columns: true
-      meta: {'test':'value'}
+      meta:
+        test: value
     columns:
       - name: id
-        meta: {'primary_key': 'true'}
+        meta:
+          primary_key: true
 ```
 
 See [persist docs](https://docs.getdbt.com/reference/resource-configs/persist_docs) for more details.

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1017,7 +1017,7 @@ class AthenaAdapter(SQLAdapter):
                     # Get dbt model column meta if available
                     col_meta: Dict[str, Any] = model["columns"][col_name].get("meta", {})
                     # Add empty Parameters dictionary if not present
-                    if len(col_meta) > 0 and "Parameters" not in col_obj.keys():
+                    if col_meta and "Parameters" not in col_obj.keys():
                         col_obj["Parameters"] = {}
                     # Prepare meta values for column properties and check if update is required
                     for meta_key, meta_value_raw in col_meta.items():

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -712,7 +712,7 @@ class AthenaAdapter(SQLAdapter):
             else:
                 raise e
 
-        relations: list[BaseRelation] = []
+        relations: List[BaseRelation] = []
         quote_policy = {"database": True, "schema": True, "identifier": True}
         for table in tables:
             if "TableType" not in table:
@@ -956,6 +956,7 @@ class AthenaAdapter(SQLAdapter):
         # Prepare new version of Glue Table picking up significant fields
         table_input = self._get_table_input(table)
         table_parameters = table_input["Parameters"]
+
         # Update table description
         if persist_relation_docs:
             # Prepare dbt description
@@ -1012,6 +1013,29 @@ class AthenaAdapter(SQLAdapter):
                         need_to_update_table = True
                     # Save column description from dbt
                     col_obj["Comment"] = clean_col_comment
+
+                    # Get dbt model column meta if available
+                    col_meta: Dict[str, Any] = model["columns"][col_name].get("meta", {})
+                    # Add empty Parameters dictionary if not present
+                    if len(col_meta) > 0 and "Parameters" not in col_obj.keys():
+                        col_obj["Parameters"] = {}
+                    # Prepare meta values for column properties and check if update is required
+                    for meta_key, meta_value_raw in col_meta.items():
+                        if is_valid_table_parameter_key(meta_key):
+                            meta_value = stringify_table_parameter_value(meta_value_raw)
+                            if meta_value is not None:
+                                # Check if meta value is already attached to Glue column
+                                col_current_meta_value: Optional[str] = col_obj["Parameters"].get(meta_key)
+                                if col_current_meta_value is None or col_current_meta_value != meta_value:
+                                    need_to_update_table = True
+                                # Save Glue column parameter
+                                col_obj["Parameters"][meta_key] = meta_value
+                            else:
+                                LOGGER.warning(
+                                    f"Column meta value for key '{meta_key}' is not supported and will be ignored"
+                                )
+                        else:
+                            LOGGER.warning(f"Column meta key '{meta_key}' is not supported and will be ignored")
 
         # Update Glue Table only if table/column description is modified.
         # It prevents redundant schema version creating after incremental runs.

--- a/dbt/include/athena/macros/adapters/persist_docs.sql
+++ b/dbt/include/athena/macros/adapters/persist_docs.sql
@@ -1,5 +1,5 @@
 {% macro athena__persist_docs(relation, model, for_relation=true, for_columns=true) -%}
-  {% set persist_relation_docs = for_relation and config.persist_relation_docs() and model.description %}
+  {% set persist_relation_docs = for_relation and config.persist_relation_docs()%}
   {% set persist_column_docs = for_columns and config.persist_column_docs() and model.columns %}
   {% if persist_relation_docs or persist_column_docs %}
     {% do adapter.persist_docs_to_glue(

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -970,6 +970,7 @@ class TestAthenaAdapter:
                     """,
                 "columns": {
                     "id": {
+                        "meta": {"primary_key": "true"},
                         "description": """
                         A column with str, 123, &^% \" and '
 
@@ -986,6 +987,7 @@ class TestAthenaAdapter:
         assert not table.get("Description", "")
         assert not table["Parameters"].get("comment")
         assert all(not col.get("Comment") for col in table["StorageDescriptor"]["Columns"])
+        assert all(not col.get("Parameters") for col in table["StorageDescriptor"]["Columns"])
 
     @mock_aws
     def test_persist_docs_to_glue_comment(self, mock_aws_service):
@@ -1009,6 +1011,7 @@ class TestAthenaAdapter:
                     """,
                 "columns": {
                     "id": {
+                        "meta": {"primary_key": True},
                         "description": """
                         A column with str, 123, &^% \" and '
 
@@ -1026,6 +1029,7 @@ class TestAthenaAdapter:
         assert table["Parameters"]["comment"] == "A table with str, 123, &^% \" and ' and an other paragraph."
         col_id = [col for col in table["StorageDescriptor"]["Columns"] if col["Name"] == "id"][0]
         assert col_id["Comment"] == "A column with str, 123, &^% \" and ' and an other paragraph."
+        assert col_id["Parameters"] == {"primary_key": "True"}
 
     @mock_aws
     def test_list_schemas(self, mock_aws_service):


### PR DESCRIPTION
# Description

Modify `persist_docs_to_glue()` so that it can update [glue column parameters](https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html) based on dbt column meta.

For example:
```
version: 2

models:
  - name: test_deduplicate
    description: another value
    config:
      persist_docs:
        relation: true
        columns: true
      meta: 
        test: banana
    columns:
      - name: id
        meta: 
          primary_key: true
```

See [slack](https://getdbt.slack.com/archives/C013MLFR7BQ/p1715167910378029) for more details

## Models used to test - Optional
Wasn't sure how to run `persist_docs_to_glue()` against my models

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [ ] You added functional testing when necessary
