### PR TITLE
chore: prepare release 1.8.0

### DIFF
--- a/dbt/adapters/athena/__version__.py
+++ b/dbt/adapters/athena/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.0rc1"
+version = "1.8.0"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 autoflake~=2.3
 black~=24.4
 boto3-stubs[s3]~=1.34
-dbt-tests-adapter~=1.8.0rc1
+dbt-tests-adapter~=1.8.0
 flake8~=7.0
 Flake8-pyproject~=1.2
 isort~=5.13

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
     install_requires=[
         "dbt-common>=1.0.0b2,<2.0",
         "dbt-adapters>=1.0.0b2,<2.0",
+        # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
+        "dbt-core>=1.8.0",
         "boto3>=1.28",
         "boto3-stubs[athena,glue,lakeformation,sts]>=1.28",
         "pyathena>=2.25,<4.0",


### PR DESCRIPTION
# Description

Prepare release 1.8.0.
As other adapters I added back dbt-core dependency in setup.py:
* [dbt-duckdb](https://github.com/duckdb/dbt-duckdb/blob/master/setup.py#L44)
* [dbt-bigquery](https://github.com/dbt-labs/dbt-bigquery/blob/main/setup.py#L64)

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
