### PR TITLE
chore: release for 1.8.0 using 1.8.1

### DIFF
--- a/dbt/adapters/athena/__version__.py
+++ b/dbt/adapters/athena/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.0"
+version = "1.8.1"


### PR DESCRIPTION
# Description

### Context
When we released the 1.8.0b1 version, an issue with setup.py, lead to parse 1.8.0b1 incorrectly, causing an upload as 1.8.0.
We fixed the setup.py, [here](https://github.com/dbt-athena/dbt-athena/pull/624) and re-upload as 1.8.0b1, and remove 1.8.0 manually from pypi. Only to discover that we cannot republish 1.8.0

### Solution
we release as 1.8.1


## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
