### PR TITLE
feat: Set unique table suffix to allow parallel incremental executions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 
 ## Getting started
 
-* Clone of fork the repo
+* Clone or fork the repo
 * Run `make setup`, it will:
   1. Install all dependencies
   2. Install pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -208,7 +208,11 @@ athena:
 - `force_batch` (`default=false`)
   - Skip creating the table as ctas and run the operation directly in batch insert mode.
   - This is particularly useful when the standard table creation process fails due to partition limitations,
-  allowing you to work with temporary tables and persist the dataset more efficiently.
+  allowing you to work with temporary tables and persist the dataset more efficiently
+- `unique_tmp_table_suffix` (`default=false`)
+  - For incremental models using insert overwrite strategy on hive table
+  - Replace the __dbt_tmp suffix used as temporary table name suffix by a unique uuid
+  - Useful if you are looking to run multiple dbt build inserting in the same table in parallel
 - `lf_tags_config` (`default=none`)
   - [AWS lakeformation](#aws-lakeformation-integration) tags to associate with the table and columns
   - `enabled` (`default=False`) whether LF tags management is enabled for a model

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -99,6 +99,7 @@ class AthenaConfig(AdapterConfig):
         seed_s3_upload_args: Dictionary containing boto3 ExtraArgs when uploading to S3.
         partitions_limit: Maximum numbers of partitions when batching.
         force_batch: Skip creating the table as ctas and run the operation directly in batch insert mode.
+        unique_tmp_table_suffix: Enforce the use of a unique id as tmp table suffix instead of __dbt_tmp.
     """
 
     work_group: Optional[str] = None
@@ -119,6 +120,7 @@ class AthenaConfig(AdapterConfig):
     seed_s3_upload_args: Optional[Dict[str, Any]] = None
     partitions_limit: Optional[int] = None
     force_batch: bool = False
+    unique_tmp_table_suffix: bool = False
 
 
 class AthenaAdapter(SQLAdapter):
@@ -418,6 +420,10 @@ class AthenaAdapter(SQLAdapter):
         # or when the table does not exist and table location is None
         if table_location := self.get_glue_table_location(relation):
             self.delete_from_s3(table_location)
+
+    @available
+    def generate_unique_temporary_table_suffix(self, suffix_initial: str = "__dbt_tmp") -> str:
+        return f"{suffix_initial}_{str(uuid4())}"
 
     def quote(self, identifier: str) -> str:
         return f"{self.quote_character}{identifier}{self.quote_character}"

--- a/tests/functional/adapter/test_unique_tmp_table_suffix.py
+++ b/tests/functional/adapter/test_unique_tmp_table_suffix.py
@@ -1,0 +1,84 @@
+import pytest
+import re
+import json
+from typing import List
+
+from dbt.contracts.results import RunStatus
+from dbt.tests.util import run_dbt
+
+models__unique_tmp_table_suffix_sql = """
+{{ config(
+        materialized='incremental',
+        incremental_strategy='insert_overwrite',
+        partitioned_by=['date_column'],
+        unique_tmp_table_suffix=True
+    )
+}}
+select
+    random() as rnd,
+    cast(from_iso8601_date('{{ var('logical_date') }}') as date) as date_column
+"""
+
+
+def extract_running_statements(dbt_run_capsys_output: str) -> List[str]:
+    base_msgs = []
+    # Skipping "Invoking dbt with ['run', '--select', 'unique_tmp_table_suffix'..."
+    for events_msg in dbt_run_capsys_output.split('\n')[1:]:
+        base_msg = None
+        # Best effort solution to avoid invalid records and blank lines
+        try:
+            base_msg = json.loads(events_msg).get('data').get('base_msg')
+        except json.JSONDecodeError:
+            pass
+        if base_msg and "Running Athena query:" in base_msg:
+            base_msgs.append(base_msg)
+    return base_msgs
+
+
+class TestUniqueTmpTableSuffix:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"unique_tmp_table_suffix.sql": models__unique_tmp_table_suffix_sql}
+
+    def test__unique_tmp_table_suffix(self, project, capsys):
+        relation_name = "unique_tmp_table_suffix"
+        model_run_result_row_count_query = f"select count(*) as records from {project.test_schema}.{relation_name}"
+        expected_unique_table_name_re = r"unique_tmp_table_suffix__dbt_tmp_[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}"
+
+        first_model_run = run_dbt([
+            "run",
+            "--select", relation_name,
+            "--vars", '{"logical_date": "2024-01-01"}',
+            "--log-level", "debug", "--log-format", "json"
+        ])
+
+        first_model_run_result = first_model_run.results[0]
+
+        assert first_model_run_result.status == RunStatus.Success
+
+        out, _ = capsys.readouterr()
+        athena_running_statements = extract_running_statements(out)
+
+        # Run statements logged output should not contain unique table suffix after first run
+        assert not bool(re.search(expected_unique_table_name_re, ''.join(athena_running_statements)))
+
+        records_count_first_run = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
+
+        assert records_count_first_run == 1
+
+        incremental_model_run = run_dbt([
+            "run",
+            "--select", relation_name,
+            "--vars", '{"logical_date": "2024-01-02"}',
+            "--log-level", "debug", "--log-format", "json"
+        ])
+
+        incremental_model_run_result = incremental_model_run.results[0]
+
+        assert incremental_model_run_result.status == RunStatus.Success
+
+        out, _ = capsys.readouterr()
+        athena_running_statements = extract_running_statements(out)
+
+        # Run statements logged for subsequent incremental model runs should use unique table suffix
+        assert bool(re.search(expected_unique_table_name_re, ''.join(athena_running_statements)))

--- a/tests/functional/adapter/test_unique_tmp_table_suffix.py
+++ b/tests/functional/adapter/test_unique_tmp_table_suffix.py
@@ -20,19 +20,37 @@ select
 """
 
 
-def extract_running_statements(dbt_run_capsys_output: str) -> List[str]:
-    base_msgs = []
+def extract_running_create_statements(dbt_run_capsys_output: str) -> List[str]:
+    sql_create_statements = []
     # Skipping "Invoking dbt with ['run', '--select', 'unique_tmp_table_suffix'..."
     for events_msg in dbt_run_capsys_output.split('\n')[1:]:
-        base_msg = None
+        base_msg_data = None
         # Best effort solution to avoid invalid records and blank lines
         try:
-            base_msg = json.loads(events_msg).get('data').get('base_msg')
+            base_msg_data = json.loads(events_msg).get('data')
         except json.JSONDecodeError:
             pass
-        if base_msg and "Running Athena query:" in base_msg:
-            base_msgs.append(base_msg)
-    return base_msgs
+        '''First run will not produce data.sql object in the execution logs, only data.base_msg
+        containing the "Running Athena query:" initial create statement.
+        Subsequent incremental runs will only contain the insert from the tmp table into the model
+        table destination.
+        Since we want to compare both run create statements, we need to handle both cases'''
+        if base_msg_data:
+            base_msg = base_msg_data.get('base_msg')
+            if "Running Athena query:" in str(base_msg):
+                if "create table" in base_msg:
+                    sql_create_statements.append(base_msg)
+
+            if base_msg_data.get('conn_name') == "model.test.unique_tmp_table_suffix" and 'sql' in base_msg_data:
+                if "create table" in base_msg_data.get('sql'):
+                    sql_create_statements.append(base_msg_data.get('sql'))
+
+    return sql_create_statements
+
+
+def extract_create_statement_table_names(sql_create_statement: str) -> List[str]:
+    table_names = re.findall(r'(?s)(?<=create table ).*?(?=with)', sql_create_statement)
+    return [table_name.rstrip() for table_name in table_names]
 
 
 class TestUniqueTmpTableSuffix:
@@ -57,10 +75,14 @@ class TestUniqueTmpTableSuffix:
         assert first_model_run_result.status == RunStatus.Success
 
         out, _ = capsys.readouterr()
-        athena_running_statements = extract_running_statements(out)
+        athena_running_create_statements = extract_running_create_statements(out)
+
+        assert len(athena_running_create_statements) == 1
+
+        first_model_run_result_table_name = extract_create_statement_table_names(athena_running_create_statements[0])[0]
 
         # Run statements logged output should not contain unique table suffix after first run
-        assert not bool(re.search(expected_unique_table_name_re, ''.join(athena_running_statements)))
+        assert not bool(re.search(expected_unique_table_name_re, first_model_run_result_table_name))
 
         records_count_first_run = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
 
@@ -78,7 +100,31 @@ class TestUniqueTmpTableSuffix:
         assert incremental_model_run_result.status == RunStatus.Success
 
         out, _ = capsys.readouterr()
-        athena_running_statements = extract_running_statements(out)
+        athena_running_create_statements = extract_running_create_statements(out)
+
+        assert len(athena_running_create_statements) == 1
+
+        incremental_model_run_result_table_name = extract_create_statement_table_names(athena_running_create_statements[0])[0]
 
         # Run statements logged for subsequent incremental model runs should use unique table suffix
-        assert bool(re.search(expected_unique_table_name_re, ''.join(athena_running_statements)))
+        assert bool(re.search(expected_unique_table_name_re, incremental_model_run_result_table_name))
+
+        assert first_model_run_result_table_name != incremental_model_run_result_table_name
+
+        incremental_model_run_2 = run_dbt([
+            "run",
+            "--select", relation_name,
+            "--vars", '{"logical_date": "2024-01-03"}',
+            "--log-level", "debug", "--log-format", "json"
+        ])
+
+        incremental_model_run_result = incremental_model_run_2.results[0]
+
+        assert incremental_model_run_result.status == RunStatus.Success
+
+        out, _ = capsys.readouterr()
+        athena_running_create_statements = extract_running_create_statements(out)
+
+        incremental_model_run_result_table_name_2 = extract_create_statement_table_names(athena_running_create_statements[0])[0]
+
+        assert incremental_model_run_result_table_name != incremental_model_run_result_table_name_2

--- a/tests/functional/adapter/test_unique_tmp_table_suffix.py
+++ b/tests/functional/adapter/test_unique_tmp_table_suffix.py
@@ -1,7 +1,8 @@
-import pytest
-import re
 import json
+import re
 from typing import List
+
+import pytest
 
 from dbt.contracts.results import RunStatus
 from dbt.tests.util import run_dbt
@@ -23,33 +24,33 @@ select
 def extract_running_create_statements(dbt_run_capsys_output: str) -> List[str]:
     sql_create_statements = []
     # Skipping "Invoking dbt with ['run', '--select', 'unique_tmp_table_suffix'..."
-    for events_msg in dbt_run_capsys_output.split('\n')[1:]:
+    for events_msg in dbt_run_capsys_output.split("\n")[1:]:
         base_msg_data = None
         # Best effort solution to avoid invalid records and blank lines
         try:
-            base_msg_data = json.loads(events_msg).get('data')
+            base_msg_data = json.loads(events_msg).get("data")
         except json.JSONDecodeError:
             pass
-        '''First run will not produce data.sql object in the execution logs, only data.base_msg
+        """First run will not produce data.sql object in the execution logs, only data.base_msg
         containing the "Running Athena query:" initial create statement.
         Subsequent incremental runs will only contain the insert from the tmp table into the model
         table destination.
-        Since we want to compare both run create statements, we need to handle both cases'''
+        Since we want to compare both run create statements, we need to handle both cases"""
         if base_msg_data:
-            base_msg = base_msg_data.get('base_msg')
+            base_msg = base_msg_data.get("base_msg")
             if "Running Athena query:" in str(base_msg):
                 if "create table" in base_msg:
                     sql_create_statements.append(base_msg)
 
-            if base_msg_data.get('conn_name') == "model.test.unique_tmp_table_suffix" and 'sql' in base_msg_data:
-                if "create table" in base_msg_data.get('sql'):
-                    sql_create_statements.append(base_msg_data.get('sql'))
+            if base_msg_data.get("conn_name") == "model.test.unique_tmp_table_suffix" and "sql" in base_msg_data:
+                if "create table" in base_msg_data.get("sql"):
+                    sql_create_statements.append(base_msg_data.get("sql"))
 
     return sql_create_statements
 
 
 def extract_create_statement_table_names(sql_create_statement: str) -> List[str]:
-    table_names = re.findall(r'(?s)(?<=create table ).*?(?=with)', sql_create_statement)
+    table_names = re.findall(r"(?s)(?<=create table ).*?(?=with)", sql_create_statement)
     return [table_name.rstrip() for table_name in table_names]
 
 
@@ -61,14 +62,24 @@ class TestUniqueTmpTableSuffix:
     def test__unique_tmp_table_suffix(self, project, capsys):
         relation_name = "unique_tmp_table_suffix"
         model_run_result_row_count_query = f"select count(*) as records from {project.test_schema}.{relation_name}"
-        expected_unique_table_name_re = r"unique_tmp_table_suffix__dbt_tmp_[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}"
+        expected_unique_table_name_re = (
+            r"unique_tmp_table_suffix__dbt_tmp_"
+            r"[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}"
+        )
 
-        first_model_run = run_dbt([
-            "run",
-            "--select", relation_name,
-            "--vars", '{"logical_date": "2024-01-01"}',
-            "--log-level", "debug", "--log-format", "json"
-        ])
+        first_model_run = run_dbt(
+            [
+                "run",
+                "--select",
+                relation_name,
+                "--vars",
+                '{"logical_date": "2024-01-01"}',
+                "--log-level",
+                "debug",
+                "--log-format",
+                "json",
+            ]
+        )
 
         first_model_run_result = first_model_run.results[0]
 
@@ -88,12 +99,19 @@ class TestUniqueTmpTableSuffix:
 
         assert records_count_first_run == 1
 
-        incremental_model_run = run_dbt([
-            "run",
-            "--select", relation_name,
-            "--vars", '{"logical_date": "2024-01-02"}',
-            "--log-level", "debug", "--log-format", "json"
-        ])
+        incremental_model_run = run_dbt(
+            [
+                "run",
+                "--select",
+                relation_name,
+                "--vars",
+                '{"logical_date": "2024-01-02"}',
+                "--log-level",
+                "debug",
+                "--log-format",
+                "json",
+            ]
+        )
 
         incremental_model_run_result = incremental_model_run.results[0]
 
@@ -104,19 +122,28 @@ class TestUniqueTmpTableSuffix:
 
         assert len(athena_running_create_statements) == 1
 
-        incremental_model_run_result_table_name = extract_create_statement_table_names(athena_running_create_statements[0])[0]
+        incremental_model_run_result_table_name = extract_create_statement_table_names(
+            athena_running_create_statements[0]
+        )[0]
 
         # Run statements logged for subsequent incremental model runs should use unique table suffix
         assert bool(re.search(expected_unique_table_name_re, incremental_model_run_result_table_name))
 
         assert first_model_run_result_table_name != incremental_model_run_result_table_name
 
-        incremental_model_run_2 = run_dbt([
-            "run",
-            "--select", relation_name,
-            "--vars", '{"logical_date": "2024-01-03"}',
-            "--log-level", "debug", "--log-format", "json"
-        ])
+        incremental_model_run_2 = run_dbt(
+            [
+                "run",
+                "--select",
+                relation_name,
+                "--vars",
+                '{"logical_date": "2024-01-03"}',
+                "--log-level",
+                "debug",
+                "--log-format",
+                "json",
+            ]
+        )
 
         incremental_model_run_result = incremental_model_run_2.results[0]
 
@@ -125,6 +152,10 @@ class TestUniqueTmpTableSuffix:
         out, _ = capsys.readouterr()
         athena_running_create_statements = extract_running_create_statements(out)
 
-        incremental_model_run_result_table_name_2 = extract_create_statement_table_names(athena_running_create_statements[0])[0]
+        incremental_model_run_result_table_name_2 = extract_create_statement_table_names(
+            athena_running_create_statements[0]
+        )[0]
 
         assert incremental_model_run_result_table_name != incremental_model_run_result_table_name_2
+
+        assert first_model_run_result_table_name != incremental_model_run_result_table_name_2


### PR DESCRIPTION
# Description

For some specific cases (eg. backfill very large amount of data), we need to execute parallel multiple `dbt build` of specific incremental model in which we pass the date (or batch number) as var argument.
For example, we have a model we run every hour using Airflow for which we pass the a date relative to the Airflow scheduler.

If we want to process by batch of N hours in parallel using Airflow concurrency, we need the tmp table create by each of the dbt run to be unique. Else, you are going to end up with N insert attempting to run with the same `__dbt_tmp` name, creating conflict and ultimately creating failure.

Similar issue open here: https://github.com/Tomme/dbt-athena/issues/62

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [x] You added functional testing when necessary

Second (incremental) run model output:
```sql
-- /* {"app": "dbt", "dbt_version": "1.8.0", "profile_name": "test", "target_name": "default", "node_id": "model.test.unique_tmp_table_suffix"} */

create table "awsdatacatalog"."test17157222480613300988_test_unique_tmp_table_suffix"."unique_tmp_table_suffix__dbt_tmp_375973fa-ecdd-44dc-9a63-788abaa41832"
    with (
      table_type='hive',
    is_external=true,external_location='s3://XXX/test17157222480613300988_test_unique_tmp_table_suffix/unique_tmp_table_suffix__dbt_tmp_375973fa-ecdd-44dc-9a63-788abaa41832/1058bc6a-9eb1-4b0b-b23a-cce26c28b669',
      format='parquet'
    )
    as
      
select
    random() as rnd,
    cast(from_iso8601_date('2024-01-02') as date) as date_column
```