### PR TITLE
fix: Add wait_random_exponential for query retries

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -24,7 +24,12 @@ from pyathena.formatter import (
 from pyathena.model import AthenaQueryExecution
 from pyathena.result_set import AthenaResultSet
 from pyathena.util import RetryConfig
-from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_random_exponential
+from tenacity import (
+    Retrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from dbt.adapters.athena.config import get_boto3_config
 from dbt.adapters.athena.constants import LOGGER

--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, ContextManager, Dict, List, Optional, Tuple
 
-import tenacity
 from dbt_common.exceptions import ConnectionError, DbtRuntimeError
 from dbt_common.utils import md5
 from pyathena.connection import Connection as AthenaConnection
@@ -25,9 +24,7 @@ from pyathena.formatter import (
 from pyathena.model import AthenaQueryExecution
 from pyathena.result_set import AthenaResultSet
 from pyathena.util import RetryConfig
-from tenacity.retry import retry_if_exception
-from tenacity.stop import stop_after_attempt
-from tenacity.wait import wait_exponential
+from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_random_exponential
 
 from dbt.adapters.athena.config import get_boto3_config
 from dbt.adapters.athena.constants import LOGGER
@@ -183,7 +180,7 @@ class AthenaCursor(Cursor):
                 raise OperationalError(query_execution.state_change_reason)
             return self
 
-        retry = tenacity.Retrying(
+        retry = Retrying(
             # No need to retry if TOO_MANY_OPEN_PARTITIONS occurs.
             # Otherwise, Athena throws ICEBERG_FILESYSTEM_ERROR after retry,
             # because not all files are removed immediately after first try to create table
@@ -191,7 +188,7 @@ class AthenaCursor(Cursor):
                 lambda e: False if catch_partitions_limit and "TOO_MANY_OPEN_PARTITIONS" in str(e) else True
             ),
             stop=stop_after_attempt(self._retry_config.attempt),
-            wait=wait_exponential(
+            wait=wait_random_exponential(
                 multiplier=self._retry_config.attempt,
                 max=self._retry_config.max_delay,
                 exp_base=self._retry_config.exponential_base,


### PR DESCRIPTION
# Description

I've enabled elementary for my dbt projects. On the biggest one I'm running every dbt model as separate airflow task and I have problem on on-run-end hook level. When elementary tries to insert new data, the problem occurs on parallel model runs. I'm getting the following error
```
[2024-05-20, 11:37:52 UTC] {pod_manager.py:484} INFO - [base]   {'status': 'error', 'message': "on-run-end failed, error:\n ICEBERG_COMMIT_ERROR: Failed to commit Iceberg update to the table: . If a data manifest file was generated at 's3://.../results/dbt/f4ea24c3-29ec-43a7-bc46-a1fca4ece38c-manifest.csv', you may need to manually clean the data from locations specified in the manifest. Athena will not delete data in your account.", 'thread': 'main', 'execution_time': 0, 'num_failures': 1, 'timing_info': [], 'adapter_response': {}} 
```
The problem is because iceberg does not support concurrent inserts. I've added query retry with `wait_random_exponential` instead of `wai_exponential` on such error to fix the problem.

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [] You added unit testing when necessary
- [] You added functional testing when necessary
