### PR TITLE
fix: Fixed table_type for GOVERNED tables

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -582,7 +582,8 @@ class AthenaAdapter(SQLAdapter):
                     "column_comment": col.get("Comment", ""),
                 },
             }
-            for idx, col in enumerate(table.get("Columns", []) + table.get("PartitionKeys", []))
+            # TODO: review this code part as TableTypeDef class does not contain "Columns" attribute
+            for idx, col in enumerate(table["Columns"] + table.get("PartitionKeys", []))
         ]
 
     def _get_one_catalog(

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -47,7 +47,6 @@ from dbt.adapters.athena.lakeformation import (
 )
 from dbt.adapters.athena.python_submissions import AthenaPythonJobHelper
 from dbt.adapters.athena.relation import (
-    RELATION_TYPE_MAP,
     AthenaRelation,
     AthenaSchemaSearchMap,
     TableType,
@@ -542,12 +541,13 @@ class AthenaAdapter(SQLAdapter):
         response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=s3_prefix)
         return True if "Contents" in response else False
 
-    def _get_one_table_for_catalog(self, table: TableTypeDef, database: str) -> List[Dict[str, Any]]:
+    @staticmethod
+    def _get_one_table_for_catalog(table: TableTypeDef, database: str) -> List[Dict[str, Any]]:
         table_catalog = {
             "table_database": database,
             "table_schema": table["DatabaseName"],
             "table_name": table["Name"],
-            "table_type": RELATION_TYPE_MAP[table.get("TableType", "EXTERNAL_TABLE")].value,
+            "table_type": get_table_type(table).value,
             "table_comment": table.get("Parameters", {}).get("comment", table.get("Description", "")),
         }
         return [
@@ -563,14 +563,13 @@ class AthenaAdapter(SQLAdapter):
             for idx, col in enumerate(table["StorageDescriptor"]["Columns"] + table.get("PartitionKeys", []))
         ]
 
-    def _get_one_table_for_non_glue_catalog(
-        self, table: TableTypeDef, schema: str, database: str
-    ) -> List[Dict[str, Any]]:
+    @staticmethod
+    def _get_one_table_for_non_glue_catalog(table: TableTypeDef, schema: str, database: str) -> List[Dict[str, Any]]:
         table_catalog = {
             "table_database": database,
             "table_schema": schema,
             "table_name": table["Name"],
-            "table_type": RELATION_TYPE_MAP[table.get("TableType", "EXTERNAL_TABLE")].value,
+            "table_type": get_table_type(table).value,
             "table_comment": table.get("Parameters", {}).get("comment", ""),
         }
         return [
@@ -583,7 +582,7 @@ class AthenaAdapter(SQLAdapter):
                     "column_comment": col.get("Comment", ""),
                 },
             }
-            for idx, col in enumerate(table["Columns"] + table.get("PartitionKeys", []))
+            for idx, col in enumerate(table.get("Columns", []) + table.get("PartitionKeys", []))
         ]
 
     def _get_one_catalog(

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -8,21 +8,24 @@ TABLE_NAME = "test_table"
 
 
 class TestRelation:
-    def test__get_relation_type_table(self):
-        assert get_table_type({"Name": "name", "TableType": "table"}) == TableType.TABLE
+    @pytest.mark.parametrize(
+        ("table", "expected"),
+        [
+            ({"Name": "n", "TableType": "table"}, TableType.TABLE),
+            ({"Name": "n", "TableType": "VIRTUAL_VIEW"}, TableType.VIEW),
+            ({"Name": "n", "TableType": "EXTERNAL_TABLE", "Parameters": {"table_type": "ICEBERG"}}, TableType.ICEBERG),
+        ],
+    )
+    def test__get_relation_type(self, table, expected):
+        assert get_table_type(table) == expected
 
     def test__get_relation_type_with_no_type(self):
         with pytest.raises(ValueError):
             get_table_type({"Name": "name"})
 
-    def test__get_relation_type_view(self):
-        assert get_table_type({"Name": "name", "TableType": "VIRTUAL_VIEW"}) == TableType.VIEW
-
-    def test__get_relation_type_iceberg(self):
-        assert (
-            get_table_type({"Name": "name", "TableType": "EXTERNAL_TABLE", "Parameters": {"table_type": "ICEBERG"}})
-            == TableType.ICEBERG
-        )
+    def test__get_relation_type_with_unknown_type(self):
+        with pytest.raises(ValueError):
+            get_table_type({"Name": "name", "TableType": "test"})
 
 
 class TestAthenaRelation:


### PR DESCRIPTION
# Description

with following table

```
{'Name': 'test', 'DatabaseName': 'raw', 'Owner': 'hadoop', 'CreateTime': datetime.datetime(2022, 3, 8, 15, 49, 45, tzinfo=tzlocal()), 'UpdateTime': datetime.datetime(2022, 3, 8, 15, 49, 45, tzinfo=tzlocal()), 'LastAccessTime': datetime.datetime(1970, 1, 1, 1, 0, tzinfo=tzlocal()), 'Retention': 0, 'StorageDescriptor': {'Columns': [{'Name': 'brand', 'Type': 'string'}, {'Name': 'dt', 'Type': 'timestamp'}], 'Location': 's3://stage-dwh-transformed/brand_governed', 'InputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat', 'OutputFormat': 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat', 'Compressed': False, 'NumberOfBuckets': -1, 'SerdeInfo': {'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {'serialization.format': '1'}}, 'BucketColumns': [], 'SortColumns': [], 'Parameters': {}, 'SkewedInfo': {'SkewedColumnNames': [], 'SkewedColumnValues': [], 'SkewedColumnValueLocationMaps': {}}, 'StoredAsSubDirectories': False}, 'PartitionKeys': [], 'TableType': 'GOVERNED', 'Parameters': {'transient_lastDdlTime': '1646750985', 'classification': 'parquet', 'table_type': 'LAKEFORMATION_GOVERNED'}, 'CreatedBy': 'xxx', 'IsRegisteredWithLakeFormation': False, 'CatalogId': 'xxx', 'IsMultiDialectView': False}
```

I've got an error on `dbt docs generate`:

```
Encountered an error while generating catalog: 'GOVERNED'
```

I've added GOVERNED table type and improved logging as well

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
