### PR TITLE
chore: Added information about location table to readme (#628)

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,8 @@ def model(dbt, spark_session):
  runs on Trino.
 - Snapshot materializations are not supported.
 - Spark can only reference tables within the same catalog.
+- For tables created outside of the dbt tool, be sure to populate the location field or dbt will throw an error
+when trying to create the table.
 
 [pre-installed list]: https://docs.aws.amazon.com/athena/latest/ug/notebooks-spark-preinstalled-python-libraries.html
 [imported manually]: https://docs.aws.amazon.com/athena/latest/ug/notebooks-import-files-libraries.html


### PR DESCRIPTION
# Description
Closes #628 
Documentation update to README.md to inform the user about populating the locating table in AWS Glue for python models. 

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
