### PR TITLE
fix: edge case fix on iceberg target table being dropped instead on being renamed first

### DIFF
--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -132,13 +132,13 @@
           {% endcall %}
         {%- endif -%}
 
-        {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation) if old_relation else none -%}
+        {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation).value if old_relation else none -%}
 
         -- we cannot use old_bkp_relation, because it returns None if the relation doesn't exist
         -- we need to create a python object via the make_temp_relation instead
         {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
 
-        {%- if old_relation_table_type.value == 'iceberg_table' -%}
+        {%- if old_relation_table_type == 'iceberg_table' -%}
           {{ rename_relation(old_relation, old_relation_bkp) }}
         {%- else  -%}
           {%- do drop_relation_glue(old_relation) -%}
@@ -151,7 +151,7 @@
         -- therefore we can drop the old relation backup, in all other cases there is nothing to do
         -- in case of switch from hive to iceberg the backup table do not exists
         -- in case of fist run the backup table do not exists
-        {%- if old_relation_table_type.value == 'iceberg_table' -%}
+        {%- if old_relation_table_type == 'iceberg_table' -%}
           {%- do drop_relation(old_relation_bkp) -%}
         {%- endif -%}
 

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -146,10 +146,9 @@
         {{ rename_relation(tmp_relation, target_relation) }}
 
         -- old_relation_bkp might not exists in case we have a switch from hive to iceberg
-        -- if we are here old_relation_bkp was created, so we can drop it
-        -- old_bkp_relation cannot be used here, because it could returns None due to caching issues
-
-        {%- if old_relation_bkp is not none -%}
+        -- we cannot use old_bkp_relation, because result could be cached by dbt, we use instead glue apis
+        {%- set old_relation_bkp_exists = adapter.get_glue_table(old_relation_bkp) -%}
+        {%- if old_relation_bkp_exists is not none -%}
           {%- do drop_relation(old_relation_bkp) -%}
         {%- endif -%}
 

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -147,9 +147,10 @@
         -- publish the target table doing a final renaming
         {{ rename_relation(tmp_relation, target_relation) }}
 
-        -- if we are in this section of the code, the old relation exist and it's an iceberg table
-        -- therefore we can drop the old relation backup
-        -- when the old_relation_table_type is a not iceberg table, we cannot backup, and there isn't anything to drop
+        -- if old relation is iceberg_table, we have a backup
+        -- therefore we can drop the old relation backup, in all other cases there is nothing to do
+        -- in case of switch from hive to iceberg the backup table do not exists
+        -- in case of fist run the backup table do not exists
         {%- if old_relation_table_type.value == 'iceberg_table' -%}
           {%- do drop_relation(old_relation_bkp) -%}
         {%- endif -%}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -134,8 +134,11 @@
 
         {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation) -%}
 
-        {%- if old_relation_table_type == 'iceberg' -%}
-          {{ rename_relation(old_relation, old_bkp_relation) }}
+        {%- if old_relation_table_type.value == 'iceberg_table' -%}
+          -- we cannot use old_bkp_relation, because it returns None if the relation doesn't exist
+          -- we need to create a python object via the make_temp_relation instead
+          {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
+          {{ rename_relation(old_relation, old_relation_bkp) }}
         {%- else  -%}
           {%- do drop_relation_glue(old_relation) -%}
         {%- endif -%}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -147,6 +147,8 @@
 
         -- old_relation_bkp might not exists in case we have a switch from hive to iceberg
         -- we cannot use old_bkp_relation, because result could be cached by dbt, we use instead glue apis
+        -- get_glue_table returns none in case EntityNotFoundException, therefore this works well with restrictive environment
+        -- where Lakeformation is used, and allow operations in only existing objects
         {%- set old_relation_bkp_exists = adapter.get_glue_table(old_relation_bkp) -%}
         {%- if old_relation_bkp_exists is not none -%}
           {%- do drop_relation(old_relation_bkp) -%}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -147,6 +147,7 @@
 
         -- old_relation_bkp might not exists in case we have a switch from hive to iceberg
         -- if we are here old_relation_bkp was created, so we can drop it
+        -- old_bkp_relation cannot be used here, because it could returns None due to caching issues
 
         {%- if old_relation_bkp is not none -%}
           {%- do drop_relation(old_relation_bkp) -%}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -150,7 +150,7 @@
         -- if old relation is iceberg_table, we have a backup
         -- therefore we can drop the old relation backup, in all other cases there is nothing to do
         -- in case of switch from hive to iceberg the backup table do not exists
-        -- in case of fist run the backup table do not exists
+        -- in case of first run, the backup table do not exists
         {%- if old_relation_table_type == 'iceberg_table' -%}
           {%- do drop_relation(old_relation_bkp) -%}
         {%- endif -%}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -132,13 +132,13 @@
           {% endcall %}
         {%- endif -%}
 
-        {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation) if old_relation else none -%}
+        {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation).value if old_relation else none -%}
 
         -- we cannot use old_bkp_relation, because it returns None if the relation doesn't exist
         -- we need to create a python object via the make_temp_relation instead
         {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
 
-        {%- if old_relation_table_type.value == 'iceberg_table' -%}
+        {%- if old_relation_table_type == 'iceberg_table' -%}
           {{ rename_relation(old_relation, old_relation_bkp) }}
         {%- else  -%}
           {%- do drop_relation_glue(old_relation) -%}

--- a/dbt/include/athena/macros/materializations/models/table/table.sql
+++ b/dbt/include/athena/macros/materializations/models/table/table.sql
@@ -132,13 +132,13 @@
           {% endcall %}
         {%- endif -%}
 
-        {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation).value if old_relation else none -%}
+        {%- set old_relation_table_type = adapter.get_glue_table_type(old_relation) if old_relation else none -%}
 
         -- we cannot use old_bkp_relation, because it returns None if the relation doesn't exist
         -- we need to create a python object via the make_temp_relation instead
         {%- set old_relation_bkp = make_temp_relation(old_relation, '__bkp') -%}
 
-        {%- if old_relation_table_type == 'iceberg_table' -%}
+        {%- if old_relation_table_type.value == 'iceberg_table' -%}
           {{ rename_relation(old_relation, old_relation_bkp) }}
         {%- else  -%}
           {%- do drop_relation_glue(old_relation) -%}

--- a/tests/functional/adapter/test_ha_iceberg.py
+++ b/tests/functional/adapter/test_ha_iceberg.py
@@ -67,6 +67,10 @@ class TestTableIcebergTableUnique:
         )
         assert alter_statement in out
 
+        second_models_records_count = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
+
+        assert second_models_records_count == 2
+
 
 # in case s3_data_naming=table for iceberg a compile error must be raised
 # with this test we want to be sure that this type of behavior is not violated

--- a/tests/functional/adapter/test_ha_iceberg.py
+++ b/tests/functional/adapter/test_ha_iceberg.py
@@ -43,17 +43,29 @@ class TestTableIcebergTableUnique:
     def models(self):
         return {"table_iceberg_table_unique.sql": models__table_iceberg_naming_table_unique}
 
-    def test__table_creation(self, project):
+    def test__table_creation(self, project, capsys):
         relation_name = "table_iceberg_table_unique"
         model_run_result_row_count_query = f"select count(*) as records from {project.test_schema}.{relation_name}"
 
-        model_run = run_dbt(["run", "--select", relation_name])
-        model_run_result = model_run.results[0]
-        assert model_run_result.status == RunStatus.Success
+        fist_model_run = run_dbt(["run", "--select", relation_name])
+        first_model_run_result = fist_model_run.results[0]
+        assert first_model_run_result.status == RunStatus.Success
 
-        models_records_count = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
+        first_models_records_count = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
 
-        assert models_records_count == 2
+        assert first_models_records_count == 2
+
+        second_model_run = run_dbt(["run", "-d", "--select", relation_name])
+        second_model_run_result = second_model_run.results[0]
+        assert second_model_run_result.status == RunStatus.Success
+
+        out, _ = capsys.readouterr()
+        # in case of 2nd run we expect that the target table is renamed to __bkp
+        alter_statement = (
+            f"alter table `awsdatacatalog`.`{project.test_schema}`.`{relation_name}` "
+            f"rename to `{project.test_schema}`.`{relation_name}__bkp`"
+        )
+        assert alter_statement in out
 
 
 # in case s3_data_naming=table for iceberg a compile error must be raised

--- a/tests/functional/adapter/test_ha_iceberg.py
+++ b/tests/functional/adapter/test_ha_iceberg.py
@@ -65,7 +65,11 @@ class TestTableIcebergTableUnique:
             f"alter table `awsdatacatalog`.`{project.test_schema}`.`{relation_name}` "
             f"rename to `{project.test_schema}`.`{relation_name}__bkp`"
         )
+        delete_bkp_table_log = (
+            f'Deleted table from glue catalog: "awsdatacatalog"."{project.test_schema}"."{relation_name}__bkp"'
+        )
         assert alter_statement in out
+        assert delete_bkp_table_log in out
 
         second_models_records_count = project.run_sql(model_run_result_row_count_query, fetch="all")[0][0]
 


### PR DESCRIPTION
# Description

See https://getdbt.slack.com/archives/C013MLFR7BQ/p1717497450266499

Pretty much https://github.com/dbt-athena/dbt-athena/pull/625 introduced a regression that was not letting iceberg working in an full high available mode.
This PR cover the issue, and add functional tests to catch these edge case.
Plus it introduce some improvements that allow to work properly in some restrictive LF permission models, where drop can happen only on existing objects.

## Models used to test - Optional
See functional tests

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
