### PR TITLE
fix: Remove catalog from the DDL SQL generated by on_schema_change=sync_all_columns

### DIFF
--- a/dbt/adapters/athena/relation.py
+++ b/dbt/adapters/athena/relation.py
@@ -26,6 +26,13 @@ class AthenaIncludePolicy(Policy):
     identifier: bool = True
 
 
+@dataclass
+class AthenaHiveIncludePolicy(Policy):
+    database: bool = False
+    schema: bool = True
+    identifier: bool = True
+
+
 @dataclass(frozen=True, eq=False, repr=False)
 class AthenaRelation(BaseRelation):
     quote_character: str = '"'  # Presto quote character
@@ -42,10 +49,13 @@ class AthenaRelation(BaseRelation):
         - https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL
         """
 
-        old_value = self.quote_character
+        old_quote_character = self.quote_character
         object.__setattr__(self, "quote_character", "`")  # Hive quote char
+        old_include_policy = self.include_policy
+        object.__setattr__(self, "include_policy", AthenaHiveIncludePolicy())
         rendered = self.render()
-        object.__setattr__(self, "quote_character", old_value)
+        object.__setattr__(self, "quote_character", old_quote_character)
+        object.__setattr__(self, "include_policy", old_include_policy)
         return str(rendered)
 
     def render_pure(self) -> str:

--- a/tests/functional/adapter/test_ha_iceberg.py
+++ b/tests/functional/adapter/test_ha_iceberg.py
@@ -62,7 +62,7 @@ class TestTableIcebergTableUnique:
         out, _ = capsys.readouterr()
         # in case of 2nd run we expect that the target table is renamed to __bkp
         alter_statement = (
-            f"alter table `awsdatacatalog`.`{project.test_schema}`.`{relation_name}` "
+            f"alter table `{project.test_schema}`.`{relation_name}` "
             f"rename to `{project.test_schema}`.`{relation_name}__bkp`"
         )
         delete_bkp_table_log = (

--- a/tests/functional/adapter/test_hive_on_schema_change.py
+++ b/tests/functional/adapter/test_hive_on_schema_change.py
@@ -1,0 +1,38 @@
+import pytest
+
+from dbt.contracts.results import RunStatus
+from dbt.tests.util import run_dbt
+
+models__table_base_model = """
+{{
+  config(
+    materialized='incremental',
+    incremental_strategy='append',
+    on_schema_change=var("on_schema_change_strategy"),
+    table_type='hive',
+  )
+}}
+
+select
+    1 as id,
+    'test 1' as name
+{%- if is_incremental() -%},
+    current_date as updated_at
+{%- endif -%}
+"""
+
+
+class TestHiveOnSchemaChange:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"hive_on_schema_change.sql": models__table_base_model}
+
+    def test__sync_all_columns(self, project):
+        relation_name = "hive_on_schema_change"
+        args = ["run", "--select", relation_name, "--vars", '{"on_schema_change_strategy": "sync_all_columns"}']
+
+        model_run_initial = run_dbt(args)
+        assert model_run_initial.results[0].status == RunStatus.Success
+
+        model_run_incremental = run_dbt(args)
+        assert model_run_incremental.results[0].status == RunStatus.Success

--- a/tests/functional/adapter/test_hive_on_schema_change.py
+++ b/tests/functional/adapter/test_hive_on_schema_change.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dbt.contracts.results import RunStatus
-from dbt.tests.util import run_dbt
+from dbt.tests.util import run_dbt, run_dbt_and_capture
 
 models__table_base_model = """
 {{
@@ -25,10 +25,20 @@ select
 class TestHiveOnSchemaChange:
     @pytest.fixture(scope="class")
     def models(self):
-        return {"hive_on_schema_change.sql": models__table_base_model}
+        return {
+            "hive_on_schema_change_sync_all_columns.sql": models__table_base_model,
+            "hive_on_schema_change_append_new_columns.sql": models__table_base_model,
+            "hive_on_schema_change_ignore.sql": models__table_base_model,
+            "hive_on_schema_change_fail.sql": models__table_base_model,
+        }
+
+    def _column_names(self, project, relation_name):
+        result = project.run_sql(f"show columns from {relation_name}", fetch="all")
+        column_names = [row[0].strip() for row in result]
+        return column_names
 
     def test__sync_all_columns(self, project):
-        relation_name = "hive_on_schema_change"
+        relation_name = "hive_on_schema_change_sync_all_columns"
         args = ["run", "--select", relation_name, "--vars", '{"on_schema_change_strategy": "sync_all_columns"}']
 
         model_run_initial = run_dbt(args)
@@ -36,3 +46,46 @@ class TestHiveOnSchemaChange:
 
         model_run_incremental = run_dbt(args)
         assert model_run_incremental.results[0].status == RunStatus.Success
+
+        new_column_names = self._column_names(project, relation_name)
+        assert new_column_names == ["id", "name", "updated_at"]
+
+    def test__append_new_columns(self, project):
+        relation_name = "hive_on_schema_change_append_new_columns"
+        args = ["run", "--select", relation_name, "--vars", '{"on_schema_change_strategy": "append_new_columns"}']
+
+        model_run_initial = run_dbt(args)
+        assert model_run_initial.results[0].status == RunStatus.Success
+
+        model_run_incremental = run_dbt(args)
+        assert model_run_incremental.results[0].status == RunStatus.Success
+
+        new_column_names = self._column_names(project, relation_name)
+        assert new_column_names == ["id", "name", "updated_at"]
+
+    def test__ignore(self, project):
+        relation_name = "hive_on_schema_change_ignore"
+        args = ["run", "--select", relation_name, "--vars", '{"on_schema_change_strategy": "ignore"}']
+
+        model_run_initial = run_dbt(args)
+        assert model_run_initial.results[0].status == RunStatus.Success
+
+        model_run_incremental = run_dbt(args)
+        assert model_run_incremental.results[0].status == RunStatus.Success
+
+        new_column_names = self._column_names(project, relation_name)
+        assert new_column_names == ["id", "name"]
+
+    def test__fail(self, project):
+        relation_name = "hive_on_schema_change_fail"
+        args = ["run", "--select", relation_name, "--vars", '{"on_schema_change_strategy": "fail"}']
+
+        model_run_initial = run_dbt(args)
+        assert model_run_initial.results[0].status == RunStatus.Success
+
+        model_run_incremental, log = run_dbt_and_capture(args, expect_pass=False)
+        assert model_run_incremental.results[0].status == RunStatus.Error
+        assert "The source and target schemas on this incremental model are out of sync!" in log
+
+        new_column_names = self._column_names(project, relation_name)
+        assert new_column_names == ["id", "name"]

--- a/tests/functional/adapter/test_on_schema_change.py
+++ b/tests/functional/adapter/test_on_schema_change.py
@@ -18,8 +18,8 @@ models__table_base_model = """
 select
     1 as id,
     'test 1' as name
-{%- if is_incremental() -%},
-    current_date as updated_at
+{%- if is_incremental() -%}
+    ,current_date as updated_at
 {%- endif -%}
 """
 

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -29,15 +29,15 @@ class TestRelation:
 
 
 class TestAthenaRelation:
-    def test_render_hive_uses_hive_style_quotation(self):
+    def test_render_hive_uses_hive_style_quotation_and_only_schema_and_table_names(self):
         relation = AthenaRelation.create(
             identifier=TABLE_NAME,
             database=DATA_CATALOG_NAME,
             schema=DATABASE_NAME,
         )
-        assert relation.render_hive() == f"`{DATA_CATALOG_NAME}`.`{DATABASE_NAME}`.`{TABLE_NAME}`"
+        assert relation.render_hive() == f"`{DATABASE_NAME}`.`{TABLE_NAME}`"
 
-    def test_render_hive_resets_quote_character_after_call(self):
+    def test_render_hive_resets_quote_character_and_include_policy_after_call(self):
         relation = AthenaRelation.create(
             identifier=TABLE_NAME,
             database=DATA_CATALOG_NAME,


### PR DESCRIPTION
# Description

This resolves #677 

When generating Hive DDL, the relation spec must not include the catalog name (i.e. "awsdatacatalog"), only the database (schema) and table name. #677 discovered that the DDL generated when `on_schema_change` is set to `sync_all_columns` generates `alter table awsdatacatalog.schema_name.table_name replace columns (…)` (with backticks around the relation spec components, but I don't know how to make Markdown include literal backticks). This DDL fails with a syntax error.

I don't know why all DDL doesn't fail, why this was only a problem when `on_schema_change` is set to `sync_all_columns`. For example, I can see multiple `ALTER TABLE … SET TBLPROPERTIES …` that are run when I run the functional tests, and none of them have the catalog in the relation spec.

My fix makes sure that the catalog is never included when rendering relation names in Hive DDL.

There were no functional tests that covered `on_schema_change`, and since I had to add one to figure out why #677 happened, I added tests for all four modes, even though only the `sync_all_columns` mode changes in this PR.

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [x] You added functional testing when necessary
