### PR TITLE
fix: Revert "chore: Update pyupgrade requirement from ~=3.16 to ~=3.17"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,4 +12,4 @@ pytest~=8.3
 pytest-cov~=5.0
 pytest-dotenv~=0.5
 pytest-xdist~=3.6
-pyupgrade~=3.17
+pyupgrade~=3.16


### PR DESCRIPTION
Reverts dbt-athena/dbt-athena#692