### PR TITLE
fix: Query comment for create table statement

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1281,7 +1281,7 @@ class AthenaAdapter(SQLAdapter):
     @available
     def run_query_with_partitions_limit_catching(self, sql: str) -> str:
         try:
-            cursor = self._run_query(query, catch_partitions_limit=True)
+            cursor = self._run_query(sql, catch_partitions_limit=True)
         except OperationalError as e:
             if "TOO_MANY_OPEN_PARTITIONS" in str(e):
                 return "TOO_MANY_OPEN_PARTITIONS"

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1281,7 +1281,8 @@ class AthenaAdapter(SQLAdapter):
     @available
     def run_query_with_partitions_limit_catching(self, sql: str) -> str:
         try:
-            cursor = self._run_query(sql, catch_partitions_limit=True)
+            query = self.connections._add_query_comment(sql)
+            cursor = self._run_query(query, catch_partitions_limit=True)
         except OperationalError as e:
             if "TOO_MANY_OPEN_PARTITIONS" in str(e):
                 return "TOO_MANY_OPEN_PARTITIONS"

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1281,7 +1281,6 @@ class AthenaAdapter(SQLAdapter):
     @available
     def run_query_with_partitions_limit_catching(self, sql: str) -> str:
         try:
-            query = self.connections._add_query_comment(sql)
             cursor = self._run_query(query, catch_partitions_limit=True)
         except OperationalError as e:
             if "TOO_MANY_OPEN_PARTITIONS" in str(e):

--- a/dbt/adapters/athena/query_headers.py
+++ b/dbt/adapters/athena/query_headers.py
@@ -25,7 +25,7 @@ class _AthenaQueryComment(_QueryComment):
 
         # alter or vacuum statements don't seem to support properly query comments
         # let's just exclude them
-        if any(map(sql.lower().__contains__, ["alter", "drop", "optimize", "vacuum", "msck"])):
+        if any(sql.lower().startswith(keyword) for keyword in ["alter", "drop", "optimize", "vacuum", "msck"]):
             return sql
 
         cleaned_query_comment = self.query_comment.strip().replace("\n", " ")


### PR DESCRIPTION
# Description
Resolve #701 
Insert query comment for queries with `vacuum_*` configs

## Models used to test - Optional
Any model with `vacuum_max_snapshot_age_seconds: 86400`

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
