### PR TITLE
fix: vacuum more runs needed error

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -1344,13 +1344,13 @@ class AthenaAdapter(SQLAdapter):
             raise ValueError(f"Unsupported column type: {column_type}")
 
     @available
-    def run_optimize_with_partition_limit_catching(self, optimize_query: str) -> None:
+    def run_operation_with_potential_multiple_runs(self, query: str, op: str) -> None:
         while True:
             try:
-                self._run_query(optimize_query, catch_partitions_limit=False)
+                self._run_query(query, catch_partitions_limit=False)
                 break
             except OperationalError as e:
-                if "ICEBERG_OPTIMIZE_MORE_RUNS_NEEDED" not in str(e):
+                if f"ICEBERG_{op.upper()}_MORE_RUNS_NEEDED" not in str(e):
                     raise e
 
     def _run_query(self, sql: str, catch_partitions_limit: bool) -> AthenaCursor:

--- a/dbt/include/athena/macros/materializations/hooks.sql
+++ b/dbt/include/athena/macros/materializations/hooks.sql
@@ -4,7 +4,9 @@
     {% set rendered = render(hook.get('sql')) | trim %}
     {% if (rendered | length) > 0 %}
       {%- if re.match("optimize\W+\S+\W+rewrite data using bin_pack", rendered.lower(), re.MULTILINE) -%}
-        {%- do adapter.run_optimize_with_partition_limit_catching(rendered) -%}
+        {%- do adapter.run_operation_with_potential_multiple_runs(rendered, "optimize") -%}
+      {%- elif re.match("vacuum\W+\S+", rendered.lower(), re.MULTILINE) -%}
+        {%- do adapter.run_operation_with_potential_multiple_runs(rendered, "vacuum") -%}
       {%- else -%}
         {% call statement(auto_begin=inside_transaction) %}
           {{ rendered }}


### PR DESCRIPTION
When there is too many files to process during a vacuum, dbt model fails with this error: "ICEBERG_VACUUM_MORE_RUNS_NEEDED: Removed 20000 files in this round of vacuum, but there are more files remaining. Please run another VACUUM command to process the remaining files."

We apply therefore the same logic as we did for the optimize. There is also an attempt to gather the code since they have the same logic.

# Description

<!--- Add a little description on what you plan to tackle with this PR -->
<!--- Add resolve #issue-number in case you resolve an open issue -->

## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->

## Checklist

- [X] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [X] You kept your Pull Request small and focused on a single feature or bug fix.
- [X] You added unit testing when necessary
- [X] You added functional testing when necessary
