### PR TITLE
fix: remove leading whitespaces on post-hook operations

### DIFF
--- a/dbt/adapters/athena/query_headers.py
+++ b/dbt/adapters/athena/query_headers.py
@@ -25,6 +25,7 @@ class _AthenaQueryComment(_QueryComment):
 
         # alter or vacuum statements don't seem to support properly query comments
         # let's just exclude them
+        sql = sql.lstrip()
         if any(sql.lower().startswith(keyword) for keyword in ["alter", "drop", "optimize", "vacuum", "msck"]):
             return sql
 

--- a/tests/unit/test_query_headers.py
+++ b/tests/unit/test_query_headers.py
@@ -74,3 +74,9 @@ class TestQueryHeaders:
         self.query_header.comment.append = True
         sql = "MSCK REPAIR TABLE"
         assert self.query_header.add(sql) == sql
+
+    def test_no_query_comment_on_vacuum_with_leading_whitespaces(self):
+        self.query_header.comment.query_comment = "executed by dbt"
+        self.query_header.comment.append = True
+        sql = "    VACUUM table"
+        assert self.query_header.add(sql) == "VACUUM table"

--- a/tests/unit/test_query_headers.py
+++ b/tests/unit/test_query_headers.py
@@ -80,3 +80,9 @@ class TestQueryHeaders:
         self.query_header.comment.append = True
         sql = "    VACUUM table"
         assert self.query_header.add(sql) == "VACUUM table"
+
+    def test_no_query_comment_on_vacuum_with_lowercase(self):
+        self.query_header.comment.query_comment = "executed by dbt"
+        self.query_header.comment.append = True
+        sql = "vacuum table"
+        assert self.query_header.add(sql) == sql


### PR DESCRIPTION
# Description
Resovles #704 
On post-hook operation vacuum, optimize presented leading whitespaces in query, even if you config looks like this:
```yaml
      +post-hook:
        - "vacuum {{ this }}"
        - "optimize {{ this }} rewrite data using bin_pack"
```
So,  lstrip() method fix it

## Checklist

- [x] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [x] You kept your Pull Request small and focused on a single feature or bug fix.
- [x] You added unit testing when necessary
- [ ] You added functional testing when necessary
