### PR TITLE
Fix: Spark-compatible tmp_table_suffix for incremental materializations

### DIFF
--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/incremental.sql
@@ -13,14 +13,8 @@
   {% set temp_schema = config.get('temp_schema') %}
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}
-  -- If using insert_overwrite on Hive table, allow to set a unique tmp table suffix
-  {% if unique_tmp_table_suffix == True and strategy == 'insert_overwrite' and table_type == 'hive' %}
-    {% set tmp_table_suffix = adapter.generate_unique_temporary_table_suffix() %}
-  {% else %}
-    {% set tmp_table_suffix = '__dbt_tmp' %}
-  {% endif %}
-
-  {% if unique_tmp_table_suffix == True and table_type == 'iceberg' %}
+  -- Generate a unique tmp table suffix if required
+  {% if unique_tmp_table_suffix == True %}
     {% set raw_suffix = adapter.generate_unique_temporary_table_suffix() %}
     {% set tmp_table_suffix = raw_suffix.replace('-', '_') %}
   {% else %}


### PR DESCRIPTION
# Description

<!--- Add a little description on what you plan to tackle with this PR -->
This PR addresses the issue related to unique_tmp_table_suffix when working with Spark. While the proposed changes in [issue #668](https://github.com/dbt-labs/dbt-athena/issues/668) worked for part of the scenarios, they did not account for Spark’s restrictions on table and view names. Specifically:
	•	Spark does not allow hyphens (-) in table/view names, causing failures when creating temporary tables.
	•	This PR modifies the logic to replace hyphens in the generated suffix with underscores (_), ensuring Spark compatibility.

Additionally:
	•	Ensures unique_tmp_table_suffix is respected and functional when set to True for all table types and strategies.
	•	Supports concurrent runs of the same model by avoiding naming conflicts.


## Models used to test - Optional
<!--- Add here the models that you use to test the changes -->
	•	incremental materialization tests with Spark, Hive, and Iceberg configurations.
	•	Test cases included concurrent runs of the same model.

## Checklist

- [ ] You followed [contributing section](https://github.com/dbt-athena/dbt-athena#contributing)
- [ ] You kept your Pull Request small and focused on a single feature or bug fix.
- [ ] You added unit testing when necessary
- [ ] You added functional testing when necessary
