### PR TITLE
adding quotes to merge condition

### DIFF
--- a/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/merge.sql
+++ b/dbt-athena/src/dbt/include/athena/macros/materializations/models/incremental/merge.sql
@@ -109,7 +109,7 @@
     {%- set merge_part -%}
       on (
           {%- for key in unique_key_cols -%}
-            target.{{ key }} = src.{{ key }}
+            target."{{ key }}" = src."{{ key }}"
             {{ " and " if not loop.last }}
           {%- endfor -%}
           {% if incremental_predicates is not none -%}


### PR DESCRIPTION
To avoid controversial namings such as "group" or "type" that throws an error, this fix enforces quoting the column names

<!---
  This repository has moved into [dbt-labs/dbt-adapters](https://www.github.com/dbt-labs/dbt-adapters).
-->
